### PR TITLE
Disable Azure Pipelines

### DIFF
--- a/PSPGP.AzurePipelines.yml
+++ b/PSPGP.AzurePipelines.yml
@@ -1,3 +1,6 @@
+trigger: none
+pr: none
+
 jobs:
   - job: Build_Windows
     pool:


### PR DESCRIPTION
## Summary
- disable Azure Pipelines by stopping triggers

## Testing
- `dotnet test Sources/PSPGP.sln` *(fails: NuGet.Config is not valid XML)*

------
https://chatgpt.com/codex/tasks/task_e_685d71d8c558832e926fe2b03538696a