### PR TITLE
Fix README typo

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@
 </p>
 
 **PSPGP** is a PowerShell module that provides PGP functionality in PowerShell. It allows encrypting and decrypting files/folders and strings using PGP.
-**PSGPG** uses following .NET library to deliver this functionality:
+**PSPGP** uses the following .NET library to deliver this functionality:
 
 - [PgpCore](https://github.com/mattosaurus/PgpCore) - licensed MIT
 


### PR DESCRIPTION
## Summary
- fix spelling of the module name when referencing PgpCore

## Testing
- `dotnet build Sources/PSPGP.sln -c Release` *(fails: Unable to load NuGet packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d76f5f164832eb0217142a38d7130