### PR TITLE
Remove duplicate variable definition

### DIFF
--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -7,7 +7,6 @@
     $KeyPublic1 = [io.path]::Combine($KeysDirectory, 'PublicPGP1.asc')
     $KeyPrivate1 = [io.path]::Combine($KeysDirectory, 'PrivatePGP1.asc')
     [string] $Script:ProtectedString = ''
-    [string] $Script:ProtectedString = ''
 
     BeforeAll {
         $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')


### PR DESCRIPTION
## Summary
- remove redundant `ProtectedString` definition in tests

## Testing
- `pwsh -NoLogo -NoProfile -File PSPGP.Tests.ps1` *(fails: Invoke-Pester not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d76e83248832e9b97930c1f8ec4ce