### PR TITLE
Support multiple keys in Test-PGP

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -79,7 +79,8 @@ Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'Ziel
 ```powershell
 $ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ProtectedString
+# Verify using one or more public keys
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Other.asc -String $ProtectedString
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Encoded
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Other.asc -FolderPath $PSScriptRoot\Encoded
 ```

--- a/Sources/PSPGP.Tests/VerificationResultTests.cs
+++ b/Sources/PSPGP.Tests/VerificationResultTests.cs
@@ -17,6 +17,7 @@ public class VerificationResultTests {
         result.FilePath.Should().BeNull("FilePath should be null by default");
         result.Status.Should().BeFalse("Status should be false by default");
         result.Error.Should().BeNull("Error should be null by default");
+        result.Signer.Should().BeNull("Signer should be null by default");
     }
 
     [Fact]
@@ -25,18 +26,21 @@ public class VerificationResultTests {
         var filePath = @"C:\test\file.pgp";
         var status = true;
         var error = "Test error message";
+        var signer = "signer.asc";
 
         // Act
         var result = new VerificationResult {
             FilePath = filePath,
             Status = status,
-            Error = error
+            Error = error,
+            Signer = signer
         };
 
         // Assert
         result.FilePath.Should().Be(filePath, "FilePath should be set correctly");
         result.Status.Should().Be(status, "Status should be set correctly");
         result.Error.Should().Be(error, "Error should be set correctly");
+        result.Signer.Should().Be(signer, "Signer should be set correctly");
     }
 
     [Fact]

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -25,7 +25,7 @@ public class CmdletTestPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
     [Parameter(Mandatory = true, ParameterSetName = "File")]
     [Parameter(Mandatory = true, ParameterSetName = "String")]
-    public string FilePathPublic { get; set; }
+    public string[] FilePathPublic { get; set; }
 
     /// <summary>Folder containing files to verify.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
@@ -49,29 +49,40 @@ public class CmdletTestPGP : PSCmdlet {
 
     protected override void ProcessRecord() {
         try {
-            string resolvedPublicKey = PathResolver.Resolve(this, FilePathPublic);
-            if (!File.Exists(resolvedPublicKey)) {
-                WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolvedPublicKey}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolvedPublicKey));
-                return;
+            var publicKeys = new List<string>();
+            foreach (var path in FilePathPublic) {
+                var resolved = PathResolver.Resolve(this, path);
+                if (!File.Exists(resolved)) {
+                    WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolved}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolved));
+                    return;
+                }
+                publicKeys.Add(resolved);
             }
-
-            var encryptionKeys = new EncryptionKeys(new FileInfo(resolvedPublicKey));
-            var pgp = new PGP(encryptionKeys);
 
             if (ParameterSetName == "Folder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
                 foreach (var file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
                     bool status = false;
                     string error = string.Empty;
-                    try {
-                        status = pgp.VerifyFile(new FileInfo(file));
-                    } catch (Exception ex) {
-                        error = ex.Message;
+                    string signer = null;
+                    foreach (var key in publicKeys) {
+                        var encryptionKeys = new EncryptionKeys(new FileInfo(key));
+                        var pgp = new PGP(encryptionKeys);
+                        try {
+                            status = pgp.VerifyFile(new FileInfo(file));
+                            if (status) {
+                                signer = key;
+                                break;
+                            }
+                        } catch (Exception ex) {
+                            error = ex.Message;
+                        }
                     }
                     var result = new VerificationResult {
                         FilePath = file,
                         Status = status,
-                        Error = error
+                        Error = status ? null : error,
+                        Signer = signer
                     };
                     WriteObject(result);
                 }
@@ -79,23 +90,49 @@ public class CmdletTestPGP : PSCmdlet {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
                 bool status = false;
                 string error = string.Empty;
-                try {
-                    status = pgp.VerifyFile(new FileInfo(resolvedFile));
-                } catch (Exception ex) {
-                    error = ex.Message;
+                string signer = null;
+                foreach (var key in publicKeys) {
+                    var encryptionKeys = new EncryptionKeys(new FileInfo(key));
+                    var pgp = new PGP(encryptionKeys);
+                    try {
+                        status = pgp.VerifyFile(new FileInfo(resolvedFile));
+                        if (status) {
+                            signer = key;
+                            break;
+                        }
+                    } catch (Exception ex) {
+                        error = ex.Message;
+                    }
                 }
                 var result = new VerificationResult {
                     FilePath = resolvedFile,
                     Status = status,
-                    Error = error
+                    Error = status ? null : error,
+                    Signer = signer
                 };
                 WriteObject(result);
             } else if (ParameterSetName == "String") {
-                try {
-                    pgp.VerifyArmoredString(String);
-                } catch (Exception ex) {
-                    WriteError(new ErrorRecord(ex, "VerifyStringFailed", ErrorCategory.NotSpecified, null));
+                bool status = false;
+                string error = string.Empty;
+                string signer = null;
+                foreach (var key in publicKeys) {
+                    var encryptionKeys = new EncryptionKeys(new FileInfo(key));
+                    var pgp = new PGP(encryptionKeys);
+                    try {
+                        pgp.VerifyArmoredString(String);
+                        status = true;
+                        signer = key;
+                        break;
+                    } catch (Exception ex) {
+                        error = ex.Message;
+                    }
                 }
+                var result = new VerificationResult {
+                    Status = status,
+                    Error = status ? null : error,
+                    Signer = signer
+                };
+                WriteObject(result);
             }
         } catch (Exception ex) {
             WriteError(new ErrorRecord(ex, "TestPGPFailed", ErrorCategory.NotSpecified, null));

--- a/Sources/PSPGP/VerificationResult.cs
+++ b/Sources/PSPGP/VerificationResult.cs
@@ -4,4 +4,5 @@ public class VerificationResult {
     public string FilePath { get; set; }
     public bool Status { get; set; }
     public string Error { get; set; }
+    public string Signer { get; set; }
 }


### PR DESCRIPTION
## Summary
- allow `Test-PGP` to take several public keys
- return which key validated the signature
- surface signer info in `VerificationResult`
- adjust unit tests and docs

## Testing
- `dotnet test Sources/PSPGP.sln --no-build --verbosity minimal` *(fails: Unable to resolve NuGet packages)*
- `dotnet build Sources/PSPGP.sln --no-restore` *(fails: reference assemblies not found and unable to resolve packages)*

------
https://chatgpt.com/codex/tasks/task_e_685d824d65fc832ebd8812b9afc9536b