### PR TITLE
Add key expiration warnings

### DIFF
--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -91,11 +91,18 @@ public class CmdletProtectPGP : PSCmdlet {
             foreach (var path in FilePathPublic) {
                 string resolved = PathResolver.Resolve(this, path);
                 if (File.Exists(resolved)) {
+                    DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                    KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
                     publicKeys.Add(new FileInfo(resolved));
                 } else {
                     WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolved}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolved));
                     return;
                 }
+            }
+
+            if (SignKey != null && SignKey.Exists) {
+                DateTime? expiration = KeyExpirationHelper.GetExpiration(SignKey.FullName);
+                KeyExpirationHelper.WarnIfExpired(this, SignKey.FullName, expiration);
             }
 
             EncryptionKeys encryptionKeys = SignKey != null ? new EncryptionKeys(publicKeys, SignKey, SignPassword) : new EncryptionKeys(publicKeys);

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -54,6 +54,8 @@ public class CmdletTestPGP : PSCmdlet {
                 WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolvedPublicKey}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolvedPublicKey));
                 return;
             }
+            DateTime? expiration = KeyExpirationHelper.GetExpiration(resolvedPublicKey);
+            KeyExpirationHelper.WarnIfExpired(this, resolvedPublicKey, expiration);
 
             var encryptionKeys = new EncryptionKeys(new FileInfo(resolvedPublicKey));
             var pgp = new PGP(encryptionKeys);

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -72,6 +72,8 @@ public class CmdletUnprotectPGP : PSCmdlet {
                 WriteWarning("Unprotect-PGP - Remove PGP encryption failed because private key file doesn't exists.");
                 return;
             }
+            DateTime? expiration = KeyExpirationHelper.GetExpiration(resolvedPrivate);
+            KeyExpirationHelper.WarnIfExpired(this, resolvedPrivate, expiration);
             string privateKey = File.ReadAllText(resolvedPrivate);
             string password = Password;
             if (Credential != null) {

--- a/Sources/PSPGP/KeyExpirationHelper.cs
+++ b/Sources/PSPGP/KeyExpirationHelper.cs
@@ -1,0 +1,56 @@
+using Org.BouncyCastle.Bcpg.OpenPgp;
+using System;
+using System.IO;
+using System.Management.Automation;
+
+namespace PSPGP;
+
+internal static class KeyExpirationHelper
+{
+    internal static DateTime? GetExpiration(string filePath)
+    {
+        using FileStream keyStream = File.OpenRead(filePath);
+        using Stream decoderStream = PgpUtilities.GetDecoderStream(keyStream);
+        PgpObjectFactory factory = new(decoderStream);
+        PgpPublicKey? publicKey = null;
+
+        object pgpObject = factory.NextPgpObject();
+        switch (pgpObject)
+        {
+            case PgpPublicKeyRing publicRing:
+                publicKey = publicRing.GetPublicKey();
+                break;
+            case PgpSecretKeyRing secretRing:
+                publicKey = secretRing.GetSecretKey().PublicKey;
+                break;
+            case PgpPublicKey key:
+                publicKey = key;
+                break;
+        }
+
+        if (publicKey != null)
+        {
+            return publicKey.GetValidSeconds() == 0
+                ? null
+                : publicKey.CreationTime.AddSeconds(publicKey.GetValidSeconds());
+        }
+
+        return null;
+    }
+
+    internal static void WarnIfExpired(PSCmdlet cmdlet, string filePath, DateTime? expiration)
+    {
+        if (expiration.HasValue)
+        {
+            DateTime now = DateTime.UtcNow;
+            if (expiration.Value <= now)
+            {
+                cmdlet.WriteWarning($"PGP key '{filePath}' expired on {expiration.Value:u}.");
+            }
+            else if (expiration.Value - now <= TimeSpan.FromDays(30))
+            {
+                cmdlet.WriteWarning($"PGP key '{filePath}' will expire on {expiration.Value:u}.");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- check key expiration when loading keys
- warn when key expired or near expiration

## Testing
- `dotnet test Sources/PSPGP.sln --verbosity minimal` *(fails: InternalLoggerException due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_e_685d8251dc70832e988c3bf11785519c