### PR TITLE
Support verifying with multiple public keys

### DIFF
--- a/Examples/Example-VerifySignature.ps1
+++ b/Examples/Example-VerifySignature.ps1
@@ -1,9 +1,11 @@
 ﻿Import-Module .\PSPGP.psd1 -Force
 
+# encrypt using first key
 $ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ProtectedString
+# verify using one or more public keys
+Test-PGP -FilePathPublic @($PSScriptRoot\Keys\PublicPGP.asc, $PSScriptRoot\Keys\PublicPGP2.asc) -String $ProtectedString
 # Expected to produce no output when signature is valid
-
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Encoded
+# verify signatures in folder with multiple keys
+Test-PGP -FilePathPublic @($PSScriptRoot\Keys\PublicPGP.asc, $PSScriptRoot\Keys\PublicPGP2.asc) -FolderPath $PSScriptRoot\Encoded
 # Returns objects with Status $true for valid signatures

--- a/README.MD
+++ b/README.MD
@@ -79,7 +79,7 @@ Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'Ziel
 ```powershell
 $ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ProtectedString
+Test-PGP -FilePathPublic @($PSScriptRoot\Keys\PublicPGP.asc, $PSScriptRoot\Keys\PublicPGP2.asc) -String $ProtectedString
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Encoded
+Test-PGP -FilePathPublic @($PSScriptRoot\Keys\PublicPGP.asc, $PSScriptRoot\Keys\PublicPGP2.asc) -FolderPath $PSScriptRoot\Encoded
 ```

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -21,11 +21,11 @@ namespace PSPGP;
 [Cmdlet(VerbsDiagnostic.Test, "PGP", DefaultParameterSetName = "File")]
 [OutputType(typeof(VerificationResult))]
 public class CmdletTestPGP : PSCmdlet {
-    /// <summary>Public key file used to verify signatures.</summary>
+    /// <summary>Public key files used to verify signatures.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
     [Parameter(Mandatory = true, ParameterSetName = "File")]
     [Parameter(Mandatory = true, ParameterSetName = "String")]
-    public string FilePathPublic { get; set; }
+    public string[] FilePathPublic { get; set; }
 
     /// <summary>Folder containing files to verify.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
@@ -49,13 +49,18 @@ public class CmdletTestPGP : PSCmdlet {
 
     protected override void ProcessRecord() {
         try {
-            string resolvedPublicKey = PathResolver.Resolve(this, FilePathPublic);
-            if (!File.Exists(resolvedPublicKey)) {
-                WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolvedPublicKey}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolvedPublicKey));
-                return;
+            var publicKeys = new List<FileInfo>();
+            foreach (var path in FilePathPublic) {
+                string resolved = PathResolver.Resolve(this, path);
+                if (File.Exists(resolved)) {
+                    publicKeys.Add(new FileInfo(resolved));
+                } else {
+                    WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolved}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolved));
+                    return;
+                }
             }
 
-            var encryptionKeys = new EncryptionKeys(new FileInfo(resolvedPublicKey));
+            var encryptionKeys = new EncryptionKeys(publicKeys);
             var pgp = new PGP(encryptionKeys);
 
             if (ParameterSetName == "Folder") {

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -43,6 +43,9 @@
 
 
     }
+    It ' Verify signature with multiple keys' -TestCases @{ ProtectedString = $ProtectedString; KeysDirectory = $KeysDirectory; KeyPublic = $KeyPublic; KeyPublic1 = $KeyPublic1 } {
+        Test-PGP -FilePathPublic $KeyPublic, $KeyPublic1 -String $Script:ProtectedString | Should -BeNullOrEmpty
+    }
     # clean everything
     AfterAll {
         $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')


### PR DESCRIPTION
## Summary
- allow Test-PGP to accept multiple public keys
- show how to verify with multiple keys in README and sample script
- test verifying signatures with multiple keys

## Testing
- `dotnet build Sources/PSPGP/PSPGP.csproj -c Release` *(fails: unable to restore packages)*
- `pwsh -NoLogo -NoProfile -Command ./Tests/PSPGP.Tests.ps1` *(fails: Describe not recognized)*

------
https://chatgpt.com/codex/tasks/task_e_685d82c5b020832e94418fc98ae06c9d