### PR TITLE
Support decrypting with multiple private keys

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -67,6 +67,12 @@ Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScri
 Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'ZielonaMila9!' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
 ```
 
+Decrypting can also be done using multiple private keys:
+
+```powershell
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc,$PSScriptRoot\Keys\PrivatePGP1.asc -Password 'ZielonaMila9!' -String $ProtectedString
+```
+
 ### Encrypt / Decrypt String
 
 ```powershell

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -56,10 +56,10 @@ public class CmdletTestPGP : PSCmdlet {
                     WriteError(new ErrorRecord(new FileNotFoundException($"Public key doesn't exist {resolved}"), "PublicKeyNotFound", ErrorCategory.InvalidArgument, resolved));
                     return;
                 }
+                DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
                 publicKeys.Add(resolved);
             }
-            DateTime? expiration = KeyExpirationHelper.GetExpiration(resolvedPublicKey);
-            KeyExpirationHelper.WarnIfExpired(this, resolvedPublicKey, expiration);
 
             if (ParameterSetName == "Folder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -1,5 +1,6 @@
 using PgpCore;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
 

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -26,7 +26,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "FileClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "StringClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "StringCredential")]
-    public string FilePathPrivate { get; set; }
+    public string[] FilePathPrivate { get; set; }
 
     /// <summary>Password protecting the private key.</summary>
     [Parameter(ParameterSetName = "FolderClearText")]
@@ -67,21 +67,22 @@ public class CmdletUnprotectPGP : PSCmdlet {
 
     protected override void ProcessRecord() {
         try {
-            string resolvedPrivate = PathResolver.Resolve(this, FilePathPrivate);
-            if (!File.Exists(resolvedPrivate)) {
-                WriteWarning("Unprotect-PGP - Remove PGP encryption failed because private key file doesn't exists.");
-                return;
+            var resolvedPrivates = new List<string>();
+            foreach (var path in FilePathPrivate) {
+                string resolved = PathResolver.Resolve(this, path);
+                if (!File.Exists(resolved)) {
+                    WriteWarning("Unprotect-PGP - Remove PGP encryption failed because private key file doesn't exists.");
+                    return;
+                }
+                DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
+                resolvedPrivates.Add(resolved);
             }
-            DateTime? expiration = KeyExpirationHelper.GetExpiration(resolvedPrivate);
-            KeyExpirationHelper.WarnIfExpired(this, resolvedPrivate, expiration);
-            string privateKey = File.ReadAllText(resolvedPrivate);
+
             string password = Password;
             if (Credential != null) {
                 password = Credential.GetNetworkCredential().Password;
             }
-
-            var encryptionKeys = new EncryptionKeys(privateKey, password);
-            var pgp = new PGP(encryptionKeys);
 
             if (ParameterSetName.StartsWith("Folder")) {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
@@ -94,7 +95,24 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         } else {
                             outputFile = file.Replace(".pgp", string.Empty);
                         }
-                        pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+
+                        bool decrypted = false;
+                        Exception lastError = null;
+                        foreach (var key in resolvedPrivates) {
+                            try {
+                                var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                                var pgp = new PGP(encryptionKeys);
+                                pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+                                decrypted = true;
+                                break;
+                            } catch (Exception ex) {
+                                lastError = ex;
+                            }
+                        }
+
+                        if (!decrypted) {
+                            WriteError(new ErrorRecord(lastError, "DecryptFileFailed", ErrorCategory.NotSpecified, file));
+                        }
                     } catch (Exception ex) {
                         WriteError(new ErrorRecord(ex, "DecryptFileFailed", ErrorCategory.NotSpecified, file));
                         return;
@@ -104,15 +122,50 @@ public class CmdletUnprotectPGP : PSCmdlet {
                 try {
                     string resolvedFile = PathResolver.Resolve(this, FilePath);
                     string outputFile = !string.IsNullOrEmpty(OutFilePath) ? PathResolver.Resolve(this, OutFilePath) : resolvedFile.Replace(".pgp", string.Empty);
-                    pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+
+                    bool decrypted = false;
+                    Exception lastError = null;
+                    foreach (var key in resolvedPrivates) {
+                        try {
+                            var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                            var pgp = new PGP(encryptionKeys);
+                            pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                            decrypted = true;
+                            break;
+                        } catch (Exception ex) {
+                            lastError = ex;
+                        }
+                    }
+
+                    if (!decrypted) {
+                        WriteError(new ErrorRecord(lastError, "DecryptFileFailed", ErrorCategory.NotSpecified, FilePath));
+                    }
                 } catch (Exception ex) {
                     WriteError(new ErrorRecord(ex, "DecryptFileFailed", ErrorCategory.NotSpecified, FilePath));
                     return;
                 }
             } else if (ParameterSetName.StartsWith("String")) {
                 try {
-                    string result = pgp.DecryptArmoredString(String);
-                    WriteObject(result);
+                    bool decrypted = false;
+                    string result = null;
+                    Exception lastError = null;
+                    foreach (var key in resolvedPrivates) {
+                        try {
+                            var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                            var pgp = new PGP(encryptionKeys);
+                            result = pgp.DecryptArmoredString(String);
+                            decrypted = true;
+                            break;
+                        } catch (Exception ex) {
+                            lastError = ex;
+                        }
+                    }
+
+                    if (decrypted) {
+                        WriteObject(result);
+                    } else {
+                        WriteError(new ErrorRecord(lastError, "DecryptStringFailed", ErrorCategory.NotSpecified, null));
+                    }
                 } catch (Exception ex) {
                     WriteError(new ErrorRecord(ex, "DecryptStringFailed", ErrorCategory.NotSpecified, null));
                 }

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -43,6 +43,11 @@
 
 
     }
+
+    It ' Decrypt string using multiple keys at once' -TestCases @{ ProtectedStringMultiple = $ProtectedStringMultiple; KeyPrivate = $KeyPrivate; KeyPrivate1 = $KeyPrivate1 } {
+        $String = Unprotect-PGP -FilePathPrivate $KeyPrivate, $KeyPrivate1 -Password 'ZielonaMila9!' -String $Script:ProtectedStringMultiple
+        $String | Should -Be "This is string to encrypt with multiple keys"
+    }
     # clean everything
     AfterAll {
         $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')


### PR DESCRIPTION
## Summary
- allow `Unprotect-PGP` to accept multiple private keys and try each sequentially
- document how to decrypt with more than one key
- add a test for decrypting with multiple keys in one command

## Testing
- `dotnet test Sources/PSPGP.sln` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*
- `pwsh -NoLogo -File Tests/PSPGP.Tests.ps1` *(fails: The term 'Describe' is not recognized)*
- `dotnet build Sources/PSPGP.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685d88668af8832eb199c55f0123dbb1