### PR TITLE
Fix warning scenario in PGP tests

### DIFF
--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -91,8 +91,15 @@
             It "$($current.Name) warns when ErrorActionPreference is Continue" -TestCases @{ CommandName = $current.Name; Params = $current.Params } {
                 param($CommandName, $Params)
                 {
-                    $paramString = ($Params.GetEnumerator() | ForEach-Object { "-$($_.Key) '$($_.Value)'" }) -join ' '
-                    Invoke-Expression "$CommandName $paramString -WarningAction SilentlyContinue"
+                    $old = $ErrorActionPreference
+                    try {
+                        $ErrorActionPreference = 'Continue'
+                        $paramString = ($Params.GetEnumerator() | ForEach-Object { "-$($_.Key) '$($_.Value)'" }) -join ' '
+                        Invoke-Expression "$CommandName $paramString -WarningAction SilentlyContinue"
+                    }
+                    finally {
+                        $ErrorActionPreference = $old
+                    }
                 } | Should -Not -Throw
             }
         }


### PR DESCRIPTION
## Summary
- ensure `$ErrorActionPreference` is restored for warning checks in tests

## Testing
- `pwsh ./PSPGP.Tests.ps1` *(fails: `Write-Color` not found)*
- `dotnet build Sources/PSPGP/PSPGP.csproj -c Release` *(fails: unable to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_685faee49ef0832ead962cefe10ae816