### PR TITLE
Add pipeline support to Get-PGPKeyInfo

### DIFF
--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -19,7 +19,7 @@ namespace PSPGP;
 [OutputType(typeof(PGPKeyInfo))]
 public class CmdletGetPGPKeyInfo : PSCmdlet {
     /// <summary>Paths to key files to inspect.</summary>
-    [Parameter(Mandatory = true)]
+    [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string[] FilePath { get; set; }
 
     protected override void ProcessRecord() {


### PR DESCRIPTION
## Summary
- allow `FilePath` parameter on `Get-PGPKeyInfo` to accept pipeline input

## Testing
- `dotnet build Sources/PSPGP/PSPGP.csproj -c Release` *(fails: unable to resolve nuget packages)*
- `pwsh -NoLogo -NoProfile -Command "Invoke-Pester"` *(fails: `Invoke-Pester` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe36782ec832eb4526fb65bdf5437