### PR TITLE
Fix grammar in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -21,7 +21,7 @@
 </p>
 
 **PSPGP** is a PowerShell module that provides PGP functionality in PowerShell. It allows encrypting and decrypting files/folders and strings using PGP.
-**PSPGP** uses the following .NET library to deliver this functionality:
+**PSPGP** uses the following .NET library:
 
 - [PgpCore](https://github.com/mattosaurus/PgpCore) - licensed MIT
 


### PR DESCRIPTION
## Summary
- update README grammar

## Testing
- `dotnet build Sources/PSPGP.sln -c Release` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685fe32ba038832e8f75849ac7c6c3b0