### PR TITLE
Add XML docs for public types

### DIFF
--- a/Sources/PSPGP/CmdletGetPGPKey.cs
+++ b/Sources/PSPGP/CmdletGetPGPKey.cs
@@ -4,14 +4,20 @@ using System.Management.Automation;
 
 namespace PSPGP;
 
+/// <summary>
+/// Downloads a public key from a key server.
+/// </summary>
 [Cmdlet(VerbsCommon.Get, "PGPKey")]
 public class CmdletGetPGPKey : PSCmdlet {
+    /// <summary>URL of the key server.</summary>
     [Parameter(Mandatory = true)]
     public string KeyServer { get; set; }
 
+    /// <summary>Search string identifying the key.</summary>
     [Parameter(Mandatory = true)]
     public string Search { get; set; }
 
+    /// <summary>File path where the downloaded key is stored.</summary>
     [Parameter]
     public string OutFilePath { get; set; }
 
@@ -30,3 +36,4 @@ public class CmdletGetPGPKey : PSCmdlet {
         }
     }
 }
+

--- a/Sources/PSPGP/KeyServerHelper.cs
+++ b/Sources/PSPGP/KeyServerHelper.cs
@@ -5,13 +5,27 @@ using System.Threading.Tasks;
 
 namespace PSPGP;
 
+/// <summary>
+/// Provides helper methods for interacting with PGP key servers.
+/// </summary>
 public static class KeyServerHelper {
+    /// <summary>
+    /// Downloads a public key from the specified key server.
+    /// </summary>
+    /// <param name="serverUri">Server from which to download the key.</param>
+    /// <param name="search">Search string identifying the key.</param>
+    /// <returns>The armored key text.</returns>
     public static async Task<string> DownloadKeyAsync(Uri serverUri, string search) {
         using HttpClient client = new();
         string url = $"{serverUri.AbsoluteUri.TrimEnd('/')}/pks/lookup?op=get&search={Uri.EscapeDataString(search)}";
         return await client.GetStringAsync(url).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Uploads a public key to the specified key server.
+    /// </summary>
+    /// <param name="serverUri">Destination key server.</param>
+    /// <param name="armoredKey">Armored public key text.</param>
     public static async Task UploadKeyAsync(Uri serverUri, string armoredKey) {
         using HttpClient client = new();
         var content = new StringContent($"keytext={Uri.EscapeDataString(armoredKey)}", Encoding.UTF8, "application/x-www-form-urlencoded");
@@ -19,3 +33,4 @@ public static class KeyServerHelper {
         response.EnsureSuccessStatusCode();
     }
 }
+

--- a/Sources/PSPGP/OnImportAndRemove.cs
+++ b/Sources/PSPGP/OnImportAndRemove.cs
@@ -3,19 +3,32 @@ using System.IO;
 using System.Management.Automation;
 using System.Reflection;
 
+/// <summary>
+/// Handles module import and removal events to resolve assemblies when running in PowerShell.
+/// </summary>
 public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemblyCleanup {
+    /// <summary>
+    /// Invoked when the module is imported.
+    /// </summary>
     public void OnImport() {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve += MyResolveEventHandler;
         }
     }
 
+    /// <summary>
+    /// Invoked when the module is removed.
+    /// </summary>
+    /// <param name="module">Module being removed.</param>
     public void OnRemove(PSModuleInfo module) {
         if (IsNetFramework()) {
             AppDomain.CurrentDomain.AssemblyResolve -= MyResolveEventHandler;
         }
     }
 
+    /// <summary>
+    /// Resolves assemblies for the module when running under .NET Framework.
+    /// </summary>
     private static Assembly MyResolveEventHandler(object sender, ResolveEventArgs args) {
         //This code is used to resolve the assemblies
         //Console.WriteLine($"Resolving {args.Name}");
@@ -34,6 +47,9 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         return null;
     }
 
+    /// <summary>
+    /// Determines whether the current runtime is .NET Framework.
+    /// </summary>
     private bool IsNetFramework() {
         // Get the version of the CLR
         Version clrVersion = System.Environment.Version;
@@ -41,10 +57,16 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
         return clrVersion.Major == 4;
     }
 
+    /// <summary>
+    /// Determines whether the current runtime is .NET Core.
+    /// </summary>
     private bool IsNetCore() {
         return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>
+    /// Determines whether the current runtime is .NET 5 or higher.
+    /// </summary>
     private bool IsNet5OrHigher() {
         return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 5", StringComparison.OrdinalIgnoreCase) ||
                System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 6", StringComparison.OrdinalIgnoreCase) ||
@@ -52,3 +74,4 @@ public class OnModuleImportAndRemove : IModuleAssemblyInitializer, IModuleAssemb
                System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription.StartsWith(".NET 8", StringComparison.OrdinalIgnoreCase);
     }
 }
+

--- a/Sources/PSPGP/PGPConfigurator.cs
+++ b/Sources/PSPGP/PGPConfigurator.cs
@@ -2,7 +2,22 @@ using Org.BouncyCastle.Bcpg;
 using PgpCore;
 
 namespace PSPGP;
+
+/// <summary>
+/// Applies optional configuration values to a <see cref="PgpCore.PGP"/> instance.
+/// </summary>
 public static class PGPConfigurator {
+    /// <summary>
+    /// Sets optional configuration parameters on a <see cref="PgpCore.PGP"/> instance.
+    /// Only values that are provided are applied.
+    /// </summary>
+    /// <param name="pgp">Instance to configure.</param>
+    /// <param name="hashAlgorithm">Hash algorithm for operations.</param>
+    /// <param name="compressionAlgorithm">Compression algorithm for operations.</param>
+    /// <param name="fileType">File type for encryption/decryption.</param>
+    /// <param name="signatureType">Signature type when signing.</param>
+    /// <param name="publicKeyAlgorithm">Public key algorithm for key creation.</param>
+    /// <param name="symmetricKeyAlgorithm">Symmetric key algorithm for encryption.</param>
     public static void Configure(
         PGP pgp,
         HashAlgorithmTag? hashAlgorithm,
@@ -19,3 +34,4 @@ public static class PGPConfigurator {
         if (symmetricKeyAlgorithm.HasValue) pgp.SymmetricKeyAlgorithm = symmetricKeyAlgorithm.Value;
     }
 }
+

--- a/Sources/PSPGP/PGPKeyInfo.cs
+++ b/Sources/PSPGP/PGPKeyInfo.cs
@@ -3,9 +3,20 @@ using System;
 
 namespace PSPGP;
 
+/// <summary>
+/// Information about a PGP key file.
+/// </summary>
 public class PGPKeyInfo {
+    /// <summary>Path to the inspected key file.</summary>
     public string FilePath { get; set; }
+
+    /// <summary>User identifiers embedded in the key.</summary>
     public string[] UserIds { get; set; }
+
+    /// <summary>Algorithm used to create the key.</summary>
     public PublicKeyAlgorithmTag Algorithm { get; set; }
+
+    /// <summary>Expiration date of the key if specified.</summary>
     public DateTime? Expiration { get; set; }
 }
+

--- a/Sources/PSPGP/PathResolver.cs
+++ b/Sources/PSPGP/PathResolver.cs
@@ -1,7 +1,18 @@
 using System.Management.Automation;
 
 namespace PSPGP;
+
+/// <summary>
+/// Resolves PowerShell paths to absolute file system paths.
+/// </summary>
 public static class PathResolver {
+    /// <summary>
+    /// Resolves the provided PowerShell path to an absolute path using the
+    /// session state of the supplied cmdlet.
+    /// </summary>
+    /// <param name="cmdlet">Cmdlet whose session state is used for resolution.</param>
+    /// <param name="path">PowerShell path to resolve.</param>
+    /// <returns>Absolute file system path.</returns>
     public static string Resolve(PSCmdlet cmdlet, string path) {
         return cmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath(path);
     }

--- a/Sources/PSPGP/VerificationResult.cs
+++ b/Sources/PSPGP/VerificationResult.cs
@@ -1,8 +1,18 @@
 namespace PSPGP;
 
+/// <summary>
+/// Represents the outcome of a signature verification operation.
+/// </summary>
 public class VerificationResult {
+    /// <summary>Path to the file that was verified.</summary>
     public string FilePath { get; set; }
+
+    /// <summary>Indicates whether the verification succeeded.</summary>
     public bool Status { get; set; }
+
+    /// <summary>Error message when verification failed.</summary>
     public string Error { get; set; }
+
+    /// <summary>Public key used to verify the signature.</summary>
     public string Signer { get; set; }
 }


### PR DESCRIPTION
## Summary
- document public helper classes and cmdlets
- add comments for `PGPConfigurator`, `PathResolver`, `KeyServerHelper`
- add comments for data types `PGPKeyInfo` and `VerificationResult`
- document the `OnModuleImportAndRemove` class

## Testing
- `dotnet build Sources/PSPGP.sln -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json)*

------
https://chatgpt.com/codex/tasks/task_e_685feb281144832ea57f2a8c1877be6a