### PR TITLE
Fix missing doc comments in cmdlets

### DIFF
--- a/Sources/PSPGP.Tests/TestFileHelper.cs
+++ b/Sources/PSPGP.Tests/TestFileHelper.cs
@@ -77,6 +77,9 @@ public class TestFileHelper : IDisposable {
         return File.ReadAllText(Path.Combine(_tempDirectory, filename));
     }
 
+    /// <summary>
+    /// Deletes any temporary files and directories created for the test.
+    /// </summary>
     public void Dispose() {
         try {
             if (Directory.Exists(_tempDirectory)) {

--- a/Sources/PSPGP.Tests/TestFileHelperTests.cs
+++ b/Sources/PSPGP.Tests/TestFileHelperTests.cs
@@ -86,6 +86,9 @@ public class TestFileHelperTests : IDisposable {
         path.Should().Be(Path.Combine(_fileHelper.TempDirectory, filename), "Should return correct path");
     }
 
+    /// <summary>
+    /// Performs cleanup of test resources.
+    /// </summary>
     public void Dispose() {
         _fileHelper?.Dispose();
     }

--- a/Sources/PSPGP/CmdletGetPGPKey.cs
+++ b/Sources/PSPGP/CmdletGetPGPKey.cs
@@ -21,6 +21,10 @@ public class CmdletGetPGPKey : PSCmdlet {
     [Parameter]
     public string OutFilePath { get; set; }
 
+    /// <summary>
+    /// Executes the cmdlet logic to download the specified public key
+    /// and optionally writes it to a file.
+    /// </summary>
     protected override void ProcessRecord() {
         try {
             Uri serverUri = new(KeyServer);
@@ -36,4 +40,3 @@ public class CmdletGetPGPKey : PSCmdlet {
         }
     }
 }
-

--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -22,6 +22,10 @@ public class CmdletGetPGPKeyInfo : PSCmdlet {
     [Parameter(Mandatory = true, ValueFromPipeline = true, ValueFromPipelineByPropertyName = true)]
     public string[] FilePath { get; set; }
 
+    /// <summary>
+    /// Processes each provided key file and emits
+    /// <see cref="PGPKeyInfo"/> objects describing the contents.
+    /// </summary>
     protected override void ProcessRecord() {
         foreach (var path in FilePath) {
             try {

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -93,6 +93,10 @@ public class CmdletNewPGPKey : PSCmdlet {
     [Parameter]
     public SymmetricKeyAlgorithmTag? SymmetricKeyAlgorithm { get; set; }
 
+    /// <summary>
+    /// Generates a new key pair based on the provided
+    /// parameters and optionally uploads the public key.
+    /// </summary>
     protected override void ProcessRecord() {
         try {
             var pgp = new PGP();

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -125,6 +125,10 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "SignString")]
     public SwitchParameter SignOnly { get; set; }
 
+    /// <summary>
+    /// Encrypts or signs input data based on the selected
+    /// parameter set and writes results to files or the pipeline.
+    /// </summary>
     protected override void ProcessRecord() {
         try {
             bool signOnlyMode = SignOnly.IsPresent || ParameterSetName.StartsWith("Sign", System.StringComparison.OrdinalIgnoreCase);

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -47,6 +47,10 @@ public class CmdletTestPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "String")]
     public string String { get; set; }
 
+    /// <summary>
+    /// Validates signatures for files, folders or strings
+    /// using the provided public keys.
+    /// </summary>
     protected override void ProcessRecord() {
         try {
             var publicKeys = new List<string>();

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -66,6 +66,10 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "StringCredential")]
     public string String { get; set; }
 
+    /// <summary>
+    /// Decrypts files or strings using the supplied private keys
+    /// and writes the decrypted data to disk or the pipeline.
+    /// </summary>
     protected override void ProcessRecord() {
         try {
             var resolvedPrivates = new List<string>();

--- a/Sources/PSPGP/ErrorActionHelper.cs
+++ b/Sources/PSPGP/ErrorActionHelper.cs
@@ -3,50 +3,60 @@ using System.Management.Automation;
 
 namespace PSPGP;
 
-internal static class ErrorActionHelper
-{
-    internal static bool IsStop(PSCmdlet cmdlet)
-    {
-        if (cmdlet.MyInvocation.BoundParameters.TryGetValue("ErrorAction", out object value))
-        {
-            if (value is ActionPreference bound)
-            {
+/// <summary>
+/// Utility methods for handling <c>-ErrorAction</c> related logic
+/// across cmdlets.
+/// </summary>
+internal static class ErrorActionHelper {
+    /// <summary>
+    /// Determines whether the specified cmdlet should treat
+    /// errors as terminating based on the <c>-ErrorAction</c>
+    /// parameter or the global preference.
+    /// </summary>
+    /// <param name="cmdlet">Cmdlet being executed.</param>
+    /// <returns><c>true</c> if error action is <see cref="ActionPreference.Stop"/>.</returns>
+    internal static bool IsStop(PSCmdlet cmdlet) {
+        if (cmdlet.MyInvocation.BoundParameters.TryGetValue("ErrorAction", out object value)) {
+            if (value is ActionPreference bound) {
                 return bound == ActionPreference.Stop;
             }
-            if (Enum.TryParse<ActionPreference>(value.ToString(), true, out var parsed))
-            {
+            if (Enum.TryParse<ActionPreference>(value.ToString(), true, out var parsed)) {
                 return parsed == ActionPreference.Stop;
             }
         }
 
         object pref = cmdlet.GetVariableValue("ErrorActionPreference");
-        if (pref is ActionPreference prefEnum)
-        {
+        if (pref is ActionPreference prefEnum) {
             return prefEnum == ActionPreference.Stop;
         }
-        if (pref != null && Enum.TryParse<ActionPreference>(pref.ToString(), true, out var parsedPref))
-        {
+        if (pref != null && Enum.TryParse<ActionPreference>(pref.ToString(), true, out var parsedPref)) {
             return parsedPref == ActionPreference.Stop;
         }
 
         return false;
     }
 
+    /// <summary>
+    /// Writes an error record or warning depending on the
+    /// cmdlet's error action preference.
+    /// </summary>
+    /// <param name="cmdlet">Cmdlet writing the message.</param>
+    /// <param name="exception">Exception to report.</param>
+    /// <param name="id">Error identifier.</param>
+    /// <param name="category">Error category.</param>
+    /// <param name="targetObject">Object associated with the error.</param>
+    /// <param name="warningMessage">Message to display when not stopping.</param>
     internal static void WriteErrorOrWarning(
         PSCmdlet cmdlet,
         Exception exception,
         string id,
         ErrorCategory category,
         object targetObject,
-        string warningMessage)
-    {
-        if (IsStop(cmdlet))
-        {
+        string warningMessage) {
+        if (IsStop(cmdlet)) {
             var record = new ErrorRecord(exception, id, category, targetObject);
             cmdlet.WriteError(record);
-        }
-        else
-        {
+        } else {
             cmdlet.WriteWarning(warningMessage);
         }
     }

--- a/Sources/PSPGP/KeyExpirationHelper.cs
+++ b/Sources/PSPGP/KeyExpirationHelper.cs
@@ -5,18 +5,24 @@ using System.Management.Automation;
 
 namespace PSPGP;
 
-internal static class KeyExpirationHelper
-{
-    internal static DateTime? GetExpiration(string filePath)
-    {
+/// <summary>
+/// Provides helpers for reading PGP key expiration
+/// information and reporting expiration warnings.
+/// </summary>
+internal static class KeyExpirationHelper {
+    /// <summary>
+    /// Reads the expiration date from the specified PGP key file.
+    /// </summary>
+    /// <param name="filePath">Path to the PGP key.</param>
+    /// <returns>The expiration date if available.</returns>
+    internal static DateTime? GetExpiration(string filePath) {
         using FileStream keyStream = File.OpenRead(filePath);
         using Stream decoderStream = PgpUtilities.GetDecoderStream(keyStream);
         PgpObjectFactory factory = new(decoderStream);
         PgpPublicKey? publicKey = null;
 
         object pgpObject = factory.NextPgpObject();
-        switch (pgpObject)
-        {
+        switch (pgpObject) {
             case PgpPublicKeyRing publicRing:
                 publicKey = publicRing.GetPublicKey();
                 break;
@@ -28,8 +34,7 @@ internal static class KeyExpirationHelper
                 break;
         }
 
-        if (publicKey != null)
-        {
+        if (publicKey != null) {
             return publicKey.GetValidSeconds() == 0
                 ? null
                 : publicKey.CreationTime.AddSeconds(publicKey.GetValidSeconds());
@@ -38,17 +43,19 @@ internal static class KeyExpirationHelper
         return null;
     }
 
-    internal static void WarnIfExpired(PSCmdlet cmdlet, string filePath, DateTime? expiration)
-    {
-        if (expiration.HasValue)
-        {
+    /// <summary>
+    /// Emits a warning from the given cmdlet if the key is expired or
+    /// expiring soon.
+    /// </summary>
+    /// <param name="cmdlet">Cmdlet writing the warning.</param>
+    /// <param name="filePath">Path to the PGP key.</param>
+    /// <param name="expiration">Expiration date of the key.</param>
+    internal static void WarnIfExpired(PSCmdlet cmdlet, string filePath, DateTime? expiration) {
+        if (expiration.HasValue) {
             DateTime now = DateTime.UtcNow;
-            if (expiration.Value <= now)
-            {
+            if (expiration.Value <= now) {
                 cmdlet.WriteWarning($"PGP key '{filePath}' expired on {expiration.Value:u}.");
-            }
-            else if (expiration.Value - now <= TimeSpan.FromDays(30))
-            {
+            } else if (expiration.Value - now <= TimeSpan.FromDays(30)) {
                 cmdlet.WriteWarning($"PGP key '{filePath}' will expire on {expiration.Value:u}.");
             }
         }


### PR DESCRIPTION
## Summary
- document cmdlet ProcessRecord methods
- add helper class XML docs
- add disposal method docs for test utilities

## Testing
- `dotnet format --no-restore Sources/PSPGP.sln` *(fails: Required references did not load)*
- `pwsh -NoLogo -NoProfile -Command 'Invoke-Pester -Configuration @{Run=@{Exit=$false}}'` *(fails: Invoke-Pester not found)*
- `dotnet test Sources/PSPGP.sln -c Release` *(fails: Unable to load the service index)*

------
https://chatgpt.com/codex/tasks/task_e_686b665a194c832e9acd30722e2c0b17