### PR TITLE
Improve PSD1 refresh workflow

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -24,6 +24,9 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+                ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref }}
 
             - name: Setup PowerShell modules
               run: |
@@ -36,6 +39,17 @@ jobs:
               run: |
                 ./Build/Build-Module.ps1
               shell: pwsh
+
+            - name: Commit refreshed PSD1
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                HEAD_BRANCH: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.ref || github.ref_name }}
+              run: |
+                git config user.name "github-actions[bot]"
+                git config user.email "github-actions[bot]@users.noreply.github.com"
+                git add PSPGP.psd1
+                git commit -m "chore: regenerate psd1" || echo "No changes to commit"
+                git push origin HEAD:$Env:HEAD_BRANCH
 
             - name: Upload refreshed manifest
               uses: actions/upload-artifact@v4

--- a/PSPGP.psd1
+++ b/PSPGP.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @()
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-PGPKeyInfo', 'Get-PGPKey', 'New-PGPKey', 'Protect-PGP', 'Test-PGP', 'Unprotect-PGP')
+    CmdletsToExport        = @('Get-PGPKey', 'Get-PGPKeyInfo', 'New-PGPKey', 'Protect-PGP', 'Test-PGP', 'Unprotect-PGP')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2025 Przemyslaw Klys @ Evotec. All rights reserved.'


### PR DESCRIPTION
## Summary
- commit refreshed psd1 from automated builds

## Testing
- `dotnet test Sources/PSPGP.Tests/PSPGP.Tests.csproj --configuration Debug --framework net8.0 --no-build --verbosity normal --logger trx --collect "XPlat Code Coverage"`
- `pwsh -NoLogo -NoProfile -Command ./PSPGP.Tests.ps1`


------
https://chatgpt.com/codex/tasks/task_e_687361366bdc832e9bf6f3ce17ee74f2