### PR TITLE
chore: limit test package exposure

### DIFF
--- a/Sources/PSPGP.Tests/PSPGP.Tests.csproj
+++ b/Sources/PSPGP.Tests/PSPGP.Tests.csproj
@@ -9,8 +9,12 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="xunit" Version="2.9.3">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
         <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
@@ -19,8 +23,12 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.4.0" />
-        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" />
+        <PackageReference Include="FluentAssertions" Version="8.4.0">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
## Summary
- hide test packages from consumers with `PrivateAssets`

## Testing
- `dotnet build Sources/PSPGP/PSPGP.csproj -c Release` *(fails: Unable to load the service index for https://api.nuget.org/v3/index.json)*
- `dotnet test Sources/PSPGP.Tests/PSPGP.Tests.csproj -c Release` *(fails: assets file not found due to missing package restore)*
- `pwsh -NoLogo -NoProfile -File PSPGP.Tests.ps1` *(fails: No match was found for the specified search criteria and module name 'Pester')*


------
https://chatgpt.com/codex/tasks/task_e_68a05626c67c832e9463d05e588fda22