### PR TITLE
Remove redundant System.Net.Http reference

### DIFF
--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -15,9 +15,6 @@
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 
-    <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
-        <Reference Include="System.Net.Http" />
-    </ItemGroup>
 
     <PropertyGroup Condition=" '$(TargetFramework)' == 'net472' ">
         <DefineConstants>$(DefineConstants);FRAMEWORK</DefineConstants>


### PR DESCRIPTION
## Summary
- clean up PSPGP project file by dropping explicit System.Net.Http reference for the net472 target

## Testing
- `MSBUILDTERMINALLOGGER=false dotnet build Sources/PSPGP/PSPGP.csproj -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json; The proxy tunnel request to proxy 'http://proxy:8080/' failed with status code '403')*
- `MSBUILDTERMINALLOGGER=false dotnet test Sources/PSPGP.Tests/PSPGP.Tests.csproj -c Release` *(fails: Unable to load the service index for source https://api.nuget.org/v3/index.json; The proxy tunnel request to proxy 'http://proxy:8080/' failed with status code '403')*
- `pwsh -NoLogo -File PSPGP.Tests.ps1` *(fails: No match was found for the specified search criteria and module name 'Pester')*

------
https://chatgpt.com/codex/tasks/task_e_68a0561dbd60832ead16a5a776aaa17a