### PR TITLE
Fix XML and nullable warnings

### DIFF
--- a/Sources/PSPGP.Tests/PathResolverTests.cs
+++ b/Sources/PSPGP.Tests/PathResolverTests.cs
@@ -16,17 +16,19 @@ namespace PSPGP.Tests;
 public class PathResolverTests {
     /// <summary>
     /// Validates that passing a null cmdlet results
-    /// in a <see cref="NullReferenceException"/>.
+    /// in an <see cref="ArgumentNullException"/>.
     /// </summary>
     [Fact]
-    public void Resolve_WithNullCmdlet_ShouldThrowNullReference() {
+    public void Resolve_WithNullCmdlet_ShouldThrowArgumentNull() {
         // Arrange
         var testPath = @"test.txt";
 
-        // Act & Assert
+        // Act
         var action = () => PathResolver.Resolve(null, testPath);
-        action.Should().Throw<NullReferenceException>()
-            .WithMessage("Object reference not set to an instance of an object.");
+
+        // Assert
+        action.Should().Throw<ArgumentNullException>()
+            .WithParameterName("cmdlet");
     }
 
     /// <summary>

--- a/Sources/PSPGP/KeyExpirationHelper.cs
+++ b/Sources/PSPGP/KeyExpirationHelper.cs
@@ -19,7 +19,7 @@ internal static class KeyExpirationHelper {
         using FileStream keyStream = File.OpenRead(filePath);
         using Stream decoderStream = PgpUtilities.GetDecoderStream(keyStream);
         PgpObjectFactory factory = new(decoderStream);
-        PgpPublicKey? publicKey = null;
+        PgpPublicKey publicKey = null;
 
         object pgpObject = factory.NextPgpObject();
         switch (pgpObject) {

--- a/Sources/PSPGP/PathResolver.cs
+++ b/Sources/PSPGP/PathResolver.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Management.Automation;
 
 namespace PSPGP;
@@ -13,10 +14,14 @@ public static class PathResolver {
     /// <param name="cmdlet">Cmdlet whose session state is used for resolution.</param>
     /// <param name="path">PowerShell path to resolve.</param>
     /// <returns>Absolute file system path.</returns>
-    /// <exception cref="NullReferenceException">
+    /// <exception cref="ArgumentNullException">
     /// Thrown when <paramref name="cmdlet"/> is <c>null</c>.
     /// </exception>
     public static string Resolve(PSCmdlet cmdlet, string path) {
+        if (cmdlet is null) {
+            throw new ArgumentNullException(nameof(cmdlet));
+        }
+
         return cmdlet.SessionState.Path.GetUnresolvedProviderPathFromPSPath(path);
     }
 }


### PR DESCRIPTION
## Summary
- validate `PathResolver.Resolve` arguments and document thrown exception
- remove stray nullable annotation in `KeyExpirationHelper`
- align tests with new `PathResolver` behavior

## Testing
- `dotnet build Sources/PSPGP/PSPGP.csproj /warnaserror`
- `dotnet test Sources/PSPGP.Tests/PSPGP.Tests.csproj`


------
https://chatgpt.com/codex/tasks/task_e_68a06a5950b0832e8e18d666e17f9e41