### PR TITLE
Add PgpCore parity features and key handling fixes

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -188,8 +188,25 @@ jobs:
               with:
                 dotnet-version: ${{ env.DOTNET_VERSION }}
 
-            - name: Install PowerShell
-              run: brew install --cask powershell
+            - name: Ensure PowerShell is available
+              shell: bash
+              run: |
+                if command -v pwsh >/dev/null 2>&1; then
+                  pwsh --version
+                  exit 0
+                fi
+
+                brew update
+                brew tap microsoft/powershell || true
+
+                if brew info --cask powershell >/dev/null 2>&1; then
+                  brew install --cask powershell
+                elif brew info --cask powershell@preview >/dev/null 2>&1; then
+                  brew install --cask powershell@preview
+                else
+                  echo "PowerShell is not available from Homebrew on this runner." >&2
+                  exit 1
+                fi
 
             - name: Install PowerShell modules
               run: |

--- a/Examples/Example-ClearSignString.ps1
+++ b/Examples/Example-ClearSignString.ps1
@@ -1,0 +1,6 @@
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
+
+$ClearSigned = Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is clear-signed text'
+$ClearSigned
+
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned

--- a/Examples/Example-DecryptFile.ps1
+++ b/Examples/Example-DecryptFile.ps1
@@ -1,11 +1,11 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
 Protect-PGP -FilePathPublic "$PSScriptRoot\Keys\PublicPGP1.asc" -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
 Unprotect-PGP -FilePathPrivate "$PSScriptRoot\Keys\PrivatePGP1.asc" -Password 'ZielonaMila9!' -FilePath $PSScriptRoot\Encoded\Test1.txt.pgp -OutFilePath $PSScriptRoot\Decoded\Test4.txt
 
-#Protect-PGP -FilePathPublic "\\ad1\c$\Temp\PublicPGP1.asc" -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
-#Unprotect-PGP -FilePathPrivate '\\ad1\c$\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath $PSScriptRoot\Encoded\Test1.txt.pgp -OutFilePath $PSScriptRoot\Decoded\Test4.txt
-#Unprotect-PGP -FilePathPrivate 'C:\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath $PSScriptRoot\Encoded\Test1.txt.pgp -OutFilePath $PSScriptRoot\Decoded\Test4.txt
+# Protect-PGP -FilePathPublic "\\ad1\c$\Temp\PublicPGP1.asc" -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
+# Unprotect-PGP -FilePathPrivate '\\ad1\c$\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath $PSScriptRoot\Encoded\Test1.txt.pgp -OutFilePath $PSScriptRoot\Decoded\Test4.txt
+# Unprotect-PGP -FilePathPrivate 'C:\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath $PSScriptRoot\Encoded\Test1.txt.pgp -OutFilePath $PSScriptRoot\Decoded\Test4.txt
 
-#Protect-PGP -FilePathPublic "\\ad1\c$\Temp\PublicPGP1.asc" -FilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1.asc" -OutFilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp"
-#Unprotect-PGP -FilePathPrivate '\\ad1\c$\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp" -OutFilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp.asc"
+# Protect-PGP -FilePathPublic "\\ad1\c$\Temp\PublicPGP1.asc" -FilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1.asc" -OutFilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp"
+# Unprotect-PGP -FilePathPrivate '\\ad1\c$\Temp\PrivatePGP1.asc' -Password 'ZielonaMila9!' -FilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp" -OutFilePath "\\AD1.AD.EVOTEC.XYZ\c`$\Temp\PrivatePGP1-Encrypted.asc.pgp.asc"

--- a/Examples/Example-DecryptFolder.ps1
+++ b/Examples/Example-DecryptFolder.ps1
@@ -1,3 +1,3 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
 Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'ZielonaMila9!' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded

--- a/Examples/Example-DecryptString.ps1
+++ b/Examples/Example-DecryptString.ps1
@@ -1,5 +1,5 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-$ProtectedString = Protect-PGP -FilePathPublic "$PSScriptRoot\Keys\PublicPGP1.asc" -String "This is string to encrypt"
+$ProtectedString = Protect-PGP -FilePathPublic "$PSScriptRoot\Keys\PublicPGP1.asc" -String 'This is string to encrypt'
 
 Unprotect-PGP -FilePathPrivate "$PSScriptRoot\Keys\PrivatePGP1.asc" -Password 'ZielonaMila9!' -String $ProtectedString

--- a/Examples/Example-DecryptVerifyString.ps1
+++ b/Examples/Example-DecryptVerifyString.ps1
@@ -1,6 +1,0 @@
-Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
-
-$EncryptedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is signed and encrypted text'
-$EncryptedString
-
-Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'ZielonaMila9!' -String $EncryptedString -Verify

--- a/Examples/Example-DecryptVerifyString.ps1
+++ b/Examples/Example-DecryptVerifyString.ps1
@@ -1,0 +1,6 @@
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
+
+$EncryptedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is signed and encrypted text'
+$EncryptedString
+
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'ZielonaMila9!' -String $EncryptedString -Verify

--- a/Examples/Example-EncryptFolder.ps1
+++ b/Examples/Example-EncryptFolder.ps1
@@ -1,3 +1,3 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded 
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded

--- a/Examples/Example-EncryptFolderMultipleKeys.ps1
+++ b/Examples/Example-EncryptFolderMultipleKeys.ps1
@@ -1,5 +1,5 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
+Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP1.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
 
-Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -FolderPath '~\Downloads\Cloudflare' -OutputFolderPath '~\Downloads\Cloudflare'
+Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP1.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -FolderPath '~\Downloads\Cloudflare' -OutputFolderPath '~\Downloads\Cloudflare'

--- a/Examples/Example-EncryptString.ps1
+++ b/Examples/Example-EncryptString.ps1
@@ -1,3 +1,3 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt" -HashAlgorithm Sha256 -CompressionAlgorithm Zip
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String 'This is string to encrypt' -HashAlgorithm Sha256 -CompressionAlgorithm Zip

--- a/Examples/Example-EncryptStringMultipleKeys.ps1
+++ b/Examples/Example-EncryptStringMultipleKeys.ps1
@@ -1,8 +1,7 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-$String = Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP1.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -String "This is string to encrypt"
+$String = Protect-PGP -FilePathPublic @("$PSScriptRoot\Keys\PublicPGP1.asc", "$PSScriptRoot\Keys\PublicPGP2.asc") -String 'This is string to encrypt'
 $String
-
 
 Unprotect-PGP -String $String -FilePathPrivate "$PSScriptRoot\Keys\PrivatePGP1.asc" -Password 'ZielonaMila9!'
 

--- a/Examples/Example-EncryptStringNoPassword.ps1
+++ b/Examples/Example-EncryptStringNoPassword.ps1
@@ -1,7 +1,7 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-# Using public key to encrypt a file
-$EncryptedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP3.asc -String "This is string to encrypt"
+# Using a public key to encrypt a string
+$EncryptedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP3.asc -String 'This is string to encrypt'
 
-# Using private key to decrypt a file without any password
+# Using a private key to decrypt a string without any password
 Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP3.asc -String $EncryptedString

--- a/Examples/Example-GeneratePGP.ps1
+++ b/Examples/Example-GeneratePGP.ps1
@@ -1,10 +1,10 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
 New-PGPKey -HashAlgorithm Sha512 -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
 New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP2.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP2.asc -Password 'ZielonaMila10!' -UserName 'przemyslaw.klys@evotec.pl'
 
 # No password is required if you don't want one and just trust the key
-#New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP3.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP3.asc -Strength 4096 -Certainty 8
+# New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP3.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP3.asc -Strength 4096 -Certainty 8
 New-PGPKey -HashAlgorithm Sha512 -FilePathPublic $PSScriptRoot\Keys\PublicPGP3.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP3.asc
 
 <#

--- a/Examples/Example-GetPGPKeyInfo.ps1
+++ b/Examples/Example-GetPGPKeyInfo.ps1
@@ -1,0 +1,3 @@
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
+
+Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc

--- a/Examples/Example-InspectSignedString.ps1
+++ b/Examples/Example-InspectSignedString.ps1
@@ -2,4 +2,4 @@ Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
 $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is signed text'
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $Signature
+Get-PGPInspect -String $Signature

--- a/Examples/Example-SymmetricString.ps1
+++ b/Examples/Example-SymmetricString.ps1
@@ -1,0 +1,6 @@
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
+
+$EncryptedString = Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'This is string to encrypt'
+$EncryptedString
+
+Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $EncryptedString

--- a/Examples/Example-VerifySignature.ps1
+++ b/Examples/Example-VerifySignature.ps1
@@ -1,9 +1,9 @@
-﻿Import-Module .\PSPGP.psd1 -Force
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
 
-$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
+$SignedString = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is signed text'
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ProtectedString
-# Expected to produce no output when signature is valid
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $SignedString
+# Returns a VerificationResult object with Status $true when the signature is valid
 
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Encoded
-# Returns objects with Status $true for valid signatures
+$ClearSigned = Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'This is clear-signed text'
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned

--- a/PSPGP.psd1
+++ b/PSPGP.psd1
@@ -1,7 +1,7 @@
 ﻿@{
     AliasesToExport        = @()
     Author                 = 'Przemyslaw Klys'
-    CmdletsToExport        = @('Get-PGPKey', 'Get-PGPKeyInfo', 'New-PGPKey', 'Protect-PGP', 'Test-PGP', 'Unprotect-PGP')
+    CmdletsToExport        = @('Get-PGPInspect', 'Get-PGPKey', 'Get-PGPKeyInfo', 'New-PGPKey', 'Protect-PGP', 'Test-PGP', 'Unprotect-PGP')
     CompanyName            = 'Evotec'
     CompatiblePSEditions   = @('Desktop', 'Core')
     Copyright              = '(c) 2011 - 2026 Przemyslaw Klys @ Evotec. All rights reserved.'

--- a/PSPGP.psd1
+++ b/PSPGP.psd1
@@ -13,7 +13,7 @@
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{
-            ExternalModuleDependencies = @('Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility')
+            ExternalModuleDependencies = @()
             IconUri                    = 'https://evotec.xyz/wp-content/uploads/2021/08/PSPGP.png'
             LicenseUri                 = 'https://github.com/EvotecIT/PSPGP/blob/master/License'
             Prerelease                 = 'Preview1'
@@ -22,6 +22,7 @@
             Tags                       = @('pgp', 'gpg', 'encrypt', 'decrypt', 'windows', 'macos', 'linux')
         }
     }
-    RequiredModules        = @('Microsoft.PowerShell.Management', 'Microsoft.PowerShell.Utility')
+    RequiredModules        = @()
     RootModule             = 'PSPGP.psm1'
+    ScriptsToProcess       = @()
 }

--- a/README.MD
+++ b/README.MD
@@ -26,6 +26,16 @@
 
 - [PgpCore](https://github.com/mattosaurus/PgpCore) - licensed MIT
 
+Exported cmdlets:
+
+- `Get-PGPInspect`
+- `Get-PGPKey`
+- `Get-PGPKeyInfo`
+- `New-PGPKey`
+- `Protect-PGP`
+- `Test-PGP`
+- `Unprotect-PGP`
+
 ## To install
 
 ```powershell
@@ -81,6 +91,13 @@ $ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc 
 Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'ZielonaMila9!' -String $ProtectedString
 ```
 
+### Encrypt / Decrypt String Symmetrically
+
+```powershell
+$ProtectedString = Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'This is string to encrypt'
+Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $ProtectedString
+```
+
 ### Verify signature
 
 ```powershell
@@ -92,9 +109,38 @@ Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Oth
 Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Other.asc -FolderPath $PSScriptRoot\Encoded
 ```
 
+### Clear sign and verify clear-signed content
+
+```powershell
+$ClearSigned = Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ClearSigned -ClearSigned
+```
+
+### Inspect message metadata
+
+```powershell
+$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
+Get-PGPInspect -String $Signature
+```
+
 ### Sign string
 
 ```powershell
 $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
 Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $Signature
+```
+
+### Encrypt, sign, decrypt and verify
+
+```powershell
+$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed and encrypted'
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -Password 'ZielonaMila9!' -String $ProtectedString -Verify
+```
+
+### Download and inspect public keys
+
+```powershell
+Get-PGPKey -KeyServer 'https://keys.openpgp.org' -Search 'user@example.com'
+Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP.asc
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -UserName 'user@example.com' -Password 'secret' -UploadKeyServer 'https://keys.openpgp.org'
 ```

--- a/README.MD
+++ b/README.MD
@@ -130,12 +130,14 @@ $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -
 Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $Signature
 ```
 
-### Encrypt, sign, decrypt and verify
+### Signed-and-encrypted verification
 
 ```powershell
 $ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed and encrypted'
 Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'ZielonaMila9!' -String $ProtectedString -Verify
 ```
+
+`Unprotect-PGP -Verify` is currently disabled on purpose. PgpCore 7.0.0 does not perform trustworthy cryptographic verification in its `DecryptAndVerify` methods, so PSPGP fails closed instead of reporting potentially forged content as verified.
 
 ### Download and inspect public keys
 
@@ -153,6 +155,5 @@ See the `Examples` folder for runnable scripts covering:
 - symmetric encryption/decryption
 - detached signatures
 - clear-sign and verify
-- decrypt and verify
 - message inspection
 - key inspection

--- a/README.MD
+++ b/README.MD
@@ -36,6 +36,8 @@ Exported cmdlets:
 - `Test-PGP`
 - `Unprotect-PGP`
 
+The checked-in sample assets under `Examples\Keys` use the `PublicPGP1.asc` / `PrivatePGP1.asc` naming pattern.
+
 ## To install
 
 ```powershell
@@ -63,32 +65,32 @@ This module works correctly on Windows/Linux and MacOS, but since it uses **.NET
 ### Create new PGP Public/Private Keys
 
 ```powershell
-New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
 ```
 
 ### Encrypt Folder
 
 ```powershell
-Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
 ```
 
 ### Decrypt Folder
 
 ```powershell
-Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'ZielonaMila9!' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'ZielonaMila9!' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
 ```
 
 Decrypting can also be done using multiple private keys:
 
 ```powershell
-Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc,$PSScriptRoot\Keys\PrivatePGP1.asc -Password 'ZielonaMila9!' -String $ProtectedString
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc,$PSScriptRoot\Keys\PrivatePGP2.asc -Password 'ZielonaMila9!' -String $ProtectedString
 ```
 
 ### Encrypt / Decrypt String
 
 ```powershell
-$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
-Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'ZielonaMila9!' -String $ProtectedString
+$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String "This is string to encrypt"
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'ZielonaMila9!' -String $ProtectedString
 ```
 
 ### Encrypt / Decrypt String Symmetrically
@@ -101,46 +103,56 @@ Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $ProtectedString
 ### Verify signature
 
 ```powershell
-$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "This is string to encrypt"
+$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
 
 # Verify using one or more public keys
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Other.asc -String $ProtectedString
-
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc,$PSScriptRoot\Keys\Other.asc -FolderPath $PSScriptRoot\Encoded
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc,$PSScriptRoot\Keys\PublicPGP2.asc -String $Signature
 ```
 
 ### Clear sign and verify clear-signed content
 
 ```powershell
-$ClearSigned = Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ClearSigned -ClearSigned
+$ClearSigned = Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned
 ```
 
 ### Inspect message metadata
 
 ```powershell
-$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
+$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
 Get-PGPInspect -String $Signature
 ```
 
 ### Sign string
 
 ```powershell
-$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $Signature
+$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $Signature
 ```
 
 ### Encrypt, sign, decrypt and verify
 
 ```powershell
-$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'ZielonaMila9!' -String 'Signed and encrypted'
-Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -Password 'ZielonaMila9!' -String $ProtectedString -Verify
+$ProtectedString = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed and encrypted'
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'ZielonaMila9!' -String $ProtectedString -Verify
 ```
 
 ### Download and inspect public keys
 
 ```powershell
 Get-PGPKey -KeyServer 'https://keys.openpgp.org' -Search 'user@example.com'
-Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP.asc
-New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -UserName 'user@example.com' -Password 'secret' -UploadKeyServer 'https://keys.openpgp.org'
+Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user@example.com' -Password 'secret' -UploadKeyServer 'https://keys.openpgp.org'
 ```
+
+### Runnable examples
+
+See the `Examples` folder for runnable scripts covering:
+
+- basic encrypt/decrypt flows
+- symmetric encryption/decryption
+- detached signatures
+- clear-sign and verify
+- decrypt and verify
+- message inspection
+- key inspection

--- a/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
+++ b/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
@@ -1,0 +1,50 @@
+using FluentAssertions;
+using PgpCore;
+using System.IO;
+using System.Text;
+using Xunit;
+
+namespace PSPGP.Tests;
+
+public class KeyMaterialHelperTests {
+    [Fact]
+    public void OpenRead_WithUtf8BomArmoredKeys_ShouldSupportEncryptAndDecrypt() {
+        using var helper = new TestFileHelper();
+
+        string publicKeyPath = helper.GetTempFilePath("public.asc");
+        string privateKeyPath = helper.GetTempFilePath("private.asc");
+        string publicKeyWithBomPath = helper.GetTempFilePath("public-bom.asc");
+        string privateKeyWithBomPath = helper.GetTempFilePath("private-bom.asc");
+        const string password = "P@ssw0rd!";
+        const string originalText = "Message encrypted with BOM-normalized keys";
+
+        var pgp = new PGP();
+        pgp.GenerateKey(new FileInfo(publicKeyPath), new FileInfo(privateKeyPath), "test@example.com", password);
+
+        File.WriteAllText(publicKeyWithBomPath, File.ReadAllText(publicKeyPath), new UTF8Encoding(true));
+        File.WriteAllText(privateKeyWithBomPath, File.ReadAllText(privateKeyPath), new UTF8Encoding(true));
+
+        using Stream publicKeyStream = KeyMaterialHelper.OpenRead(publicKeyWithBomPath);
+        var encryptionKeys = new EncryptionKeys(publicKeyStream);
+        var encryptPgp = new PGP(encryptionKeys);
+        string encrypted = encryptPgp.EncryptArmoredString(originalText);
+
+        using Stream privateKeyStream = KeyMaterialHelper.OpenRead(privateKeyWithBomPath);
+        var decryptionKeys = new EncryptionKeys(privateKeyStream, password);
+        var decryptPgp = new PGP(decryptionKeys);
+        string decrypted = decryptPgp.DecryptArmoredString(encrypted);
+
+        decrypted.Should().Be(originalText);
+    }
+
+    [Fact]
+    public void Normalize_WithPacketType20Error_ShouldReturnAeadGuidance() {
+        var exception = new IOException("unknown packet type encountered: 20");
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception);
+
+        normalized.Should().BeOfType<NotSupportedException>();
+        normalized.Message.Should().Contain("AEAD");
+        normalized.InnerException.Should().BeSameAs(exception);
+    }
+}

--- a/Sources/PSPGP.Tests/PSPGP.Tests.csproj
+++ b/Sources/PSPGP.Tests/PSPGP.Tests.csproj
@@ -9,21 +9,21 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="xunit" Version="2.9.3">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1">
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
+        <PackageReference Include="coverlet.collector" Version="8.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.4.0">
+        <PackageReference Include="FluentAssertions" Version="8.9.0">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1">

--- a/Sources/PSPGP/AssemblyInfo.cs
+++ b/Sources/PSPGP/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PSPGP.Tests")]

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -33,13 +33,16 @@ public class CmdletGetPGPInspect : PSCmdlet {
     /// Inspects the selected input and writes message metadata.
     /// </summary>
     protected override void ProcessRecord() {
+        var pgp = new PGP();
         try {
-            var pgp = new PGP();
-
             if (ParameterSetName == "Folder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
                 foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
-                    WriteObject(ToInfo(file, pgp.Inspect(new FileInfo(file))));
+                    try {
+                        WriteObject(ToInfo(file, pgp.Inspect(new FileInfo(file))));
+                    } catch (System.Exception ex) {
+                        WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, file));
+                    }
                 }
             } else if (ParameterSetName == "File") {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
@@ -48,14 +51,18 @@ public class CmdletGetPGPInspect : PSCmdlet {
                 WriteObject(ToInfo(null, pgp.Inspect(String)));
             }
         } catch (System.Exception ex) {
-            if (ex is System.NullReferenceException) {
-                ex = new System.NotSupportedException(
-                    "PgpCore inspect currently fails for some encrypted messages. Signed content inspection works, but encrypted-message inspection is limited by the upstream library.",
-                    ex);
-            }
-
-            WriteError(new ErrorRecord(ex, "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
+            WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
         }
+    }
+
+    private static System.Exception NormalizeInspectException(System.Exception exception) {
+        if (exception is System.NullReferenceException) {
+            return new System.NotSupportedException(
+                "PgpCore inspect currently fails for some encrypted messages. Signed content inspection works, but encrypted-message inspection is limited by the upstream library.",
+                exception);
+        }
+
+        return exception;
     }
 
     private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result) {

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -7,13 +7,13 @@ namespace PSPGP;
 
 /// <summary>
 /// Inspects PGP content and returns message metadata.
+/// </summary>
 /// <example>
 /// <code>
 /// $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String 'Signed text'
 /// Get-PGPInspect -String $Signature
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet(VerbsCommon.Get, "PGPInspect", DefaultParameterSetName = "File")]
 [OutputType(typeof(PGPInspectInfo))]
 public class CmdletGetPGPInspect : PSCmdlet {

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -1,0 +1,71 @@
+using System.IO;
+using System.Management.Automation;
+using PgpCore;
+using PgpCore.Models;
+
+namespace PSPGP;
+
+/// <summary>
+/// Inspects PGP content and returns message metadata.
+/// </summary>
+[Cmdlet(VerbsCommon.Get, "PGPInspect", DefaultParameterSetName = "File")]
+[OutputType(typeof(PGPInspectInfo))]
+public class CmdletGetPGPInspect : PSCmdlet {
+    /// <summary>Folder containing PGP files to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "Folder")]
+    public string FolderPath { get; set; }
+
+    /// <summary>File to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "File")]
+    public string FilePath { get; set; }
+
+    /// <summary>Armored message content to inspect.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "String")]
+    public string String { get; set; }
+
+    /// <summary>
+    /// Inspects the selected input and writes message metadata.
+    /// </summary>
+    protected override void ProcessRecord() {
+        try {
+            var pgp = new PGP();
+
+            if (ParameterSetName == "Folder") {
+                string resolvedFolder = PathResolver.Resolve(this, FolderPath);
+                foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
+                    WriteObject(ToInfo(file, pgp.Inspect(new FileInfo(file))));
+                }
+            } else if (ParameterSetName == "File") {
+                string resolvedFile = PathResolver.Resolve(this, FilePath);
+                WriteObject(ToInfo(resolvedFile, pgp.Inspect(new FileInfo(resolvedFile))));
+            } else {
+                WriteObject(ToInfo(null, pgp.Inspect(String)));
+            }
+        } catch (System.Exception ex) {
+            if (ex is System.NullReferenceException) {
+                ex = new System.NotSupportedException(
+                    "PgpCore inspect currently fails for some encrypted messages. Signed content inspection works, but encrypted-message inspection is limited by the upstream library.",
+                    ex);
+            }
+
+            WriteError(new ErrorRecord(ex, "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
+        }
+    }
+
+    private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result) {
+        return new PGPInspectInfo {
+            SourcePath = sourcePath,
+            IsArmored = result.IsArmored,
+            MessageHeaders = result.MessageHeaders,
+            Version = result.Version,
+            Comment = result.Comment,
+            IsCompressed = result.IsCompressed,
+            IsEncrypted = result.IsEncrypted,
+            IsIntegrityProtected = result.IsIntegrityProtected,
+            IsSigned = result.IsSigned,
+            SymmetricKeyAlgorithm = result.SymmetricKeyAlgorithm,
+            FileName = result.FileName,
+            ModificationDateTime = result.ModificationDateTime
+        };
+    }
+}

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -7,6 +7,12 @@ namespace PSPGP;
 
 /// <summary>
 /// Inspects PGP content and returns message metadata.
+/// <example>
+/// <code>
+/// $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String 'Signed text'
+/// Get-PGPInspect -String $Signature
+/// </code>
+/// </example>
 /// </summary>
 [Cmdlet(VerbsCommon.Get, "PGPInspect", DefaultParameterSetName = "File")]
 [OutputType(typeof(PGPInspectInfo))]

--- a/Sources/PSPGP/CmdletGetPGPKey.cs
+++ b/Sources/PSPGP/CmdletGetPGPKey.cs
@@ -6,12 +6,12 @@ namespace PSPGP;
 
 /// <summary>
 /// Downloads a public key from a key server.
+/// </summary>
 /// <example>
 /// <code>
 /// Get-PGPKey -KeyServer "https://keys.example.com" -Search "user@example.com" -OutFilePath "key.asc"
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet(VerbsCommon.Get, "PGPKey")]
 public class CmdletGetPGPKey : PSCmdlet {
     /// <summary>URL of the key server.</summary>

--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -9,12 +9,12 @@ namespace PSPGP;
 
 /// <summary>
 /// <para>Returns information about a PGP key such as algorithm, expiration and user IDs.</para>
+/// </summary>
 /// <example>
 /// <code>
 /// Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet(VerbsCommon.Get, "PGPKeyInfo")]
 [OutputType(typeof(PGPKeyInfo))]
 public class CmdletGetPGPKeyInfo : PSCmdlet {

--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -11,7 +11,7 @@ namespace PSPGP;
 /// <para>Returns information about a PGP key such as algorithm, expiration and user IDs.</para>
 /// <example>
 /// <code>
-/// Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP.asc
+/// Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
 /// </code>
 /// </example>
 /// </summary>

--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -41,7 +41,7 @@ public class CmdletGetPGPKeyInfo : PSCmdlet {
                     continue;
                 }
 
-                using FileStream keyStream = File.OpenRead(resolved);
+                using Stream keyStream = KeyMaterialHelper.OpenRead(resolved);
                 using Stream decoderStream = PgpUtilities.GetDecoderStream(keyStream);
                 PgpObjectFactory factory = new(decoderStream);
                 PgpPublicKey publicKey = null;

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PSPGP;
 /// <summary>
 /// <para>Generates a new PGP key pair.</para>
+/// </summary>
 /// <example>
 /// <code>
 /// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user' -Password 'secret'
@@ -17,7 +18,6 @@ namespace PSPGP;
 /// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 8 -EmitVersion
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet(VerbsCommon.New, "PGPKey", DefaultParameterSetName = "ClearText")]
 public class CmdletNewPGPKey : PSCmdlet {
     /// <summary>Path to the public key file to create.</summary>

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -9,12 +9,12 @@ namespace PSPGP;
 /// <para>Generates a new PGP key pair.</para>
 /// <example>
 /// <code>
-/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -UserName 'user' -Password 'secret'
+/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user' -Password 'secret'
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Strength 4096 -Certainty 8 -EmitVersion
+/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 8 -EmitVersion
 /// </code>
 /// </example>
 /// </summary>

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -14,6 +14,7 @@ namespace PSPGP;
 /// Use <c>-SignOnly</c> or the <c>Sign*</c> parameter sets to create detached
 /// signatures without encryption.
 /// </para>
+/// </summary>
 /// <example>
 /// <code>
 /// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
@@ -44,7 +45,6 @@ namespace PSPGP;
 /// Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Human readable signed content"
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet("Protect", "PGP", DefaultParameterSetName = "File")]
 public class CmdletProtectPGP : PSCmdlet {
     /// <summary>Public key files used for encryption.</summary>

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -1,9 +1,11 @@
 using Org.BouncyCastle.Bcpg;
 using PgpCore;
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
+using System.Text;
 
 namespace PSPGP;
 /// <summary>
@@ -47,27 +49,43 @@ public class CmdletProtectPGP : PSCmdlet {
     /// <summary>Folder to encrypt when using the Folder parameter set.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
     [Parameter(Mandatory = true, ParameterSetName = "SignFolder")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFolder")]
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricFolder")]
     public string FolderPath { get; set; }
 
     /// <summary>Destination folder for encrypted files.</summary>
     [Parameter(ParameterSetName = "Folder")]
     [Parameter(ParameterSetName = "SignFolder")]
+    [Parameter(ParameterSetName = "ClearSignFolder")]
+    [Parameter(ParameterSetName = "SymmetricFolder")]
     public string OutputFolderPath { get; set; }
 
     /// <summary>File to encrypt when using the File parameter set.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "File")]
     [Parameter(Mandatory = true, ParameterSetName = "SignFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricFile")]
     public string FilePath { get; set; }
 
     /// <summary>Output file path for the encrypted file.</summary>
     [Parameter(ParameterSetName = "File")]
     [Parameter(ParameterSetName = "SignFile")]
+    [Parameter(ParameterSetName = "ClearSignFile")]
+    [Parameter(ParameterSetName = "SymmetricFile")]
     public string OutFilePath { get; set; }
 
     /// <summary>String content to encrypt.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "String")]
     [Parameter(Mandatory = true, ParameterSetName = "SignString")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignString")]
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricString")]
     public string String { get; set; }
+
+    /// <summary>Passphrase used for symmetric encryption.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricFolder")]
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "SymmetricString")]
+    public string SymmetricPassphrase { get; set; }
 
     /// <summary>
     /// Private key used for signing data. Mandatory when using the
@@ -79,6 +97,9 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "SignFolder")]
     [Parameter(Mandatory = true, ParameterSetName = "SignFile")]
     [Parameter(Mandatory = true, ParameterSetName = "SignString")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFolder")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignString")]
     public FileInfo SignKey { get; set; }
 
     /// <summary>Password for the signing private key.</summary>
@@ -88,6 +109,9 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter(ParameterSetName = "SignFolder")]
     [Parameter(ParameterSetName = "SignFile")]
     [Parameter(ParameterSetName = "SignString")]
+    [Parameter(ParameterSetName = "ClearSignFolder")]
+    [Parameter(ParameterSetName = "ClearSignFile")]
+    [Parameter(ParameterSetName = "ClearSignString")]
     public string SignPassword { get; set; }
 
     /// <summary>Optional hash algorithm for encryption.</summary>
@@ -115,6 +139,27 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter]
     public SymmetricKeyAlgorithmTag? SymmetricKeyAlgorithm { get; set; }
 
+    /// <summary>Controls whether file output is armored.</summary>
+    [Parameter]
+    public bool Armor { get; set; } = true;
+
+    /// <summary>Controls whether an integrity check packet is added.</summary>
+    [Parameter]
+    public bool WithIntegrityCheck { get; set; } = true;
+
+    /// <summary>Optional literal file name embedded in the PGP payload.</summary>
+    [Parameter]
+    [Alias("Name")]
+    public string LiteralFileName { get; set; }
+
+    /// <summary>Optional armored headers added to generated content.</summary>
+    [Parameter]
+    public Hashtable Headers { get; set; }
+
+    /// <summary>Uses the legacy packet format when set.</summary>
+    [Parameter]
+    public SwitchParameter OldFormat { get; set; }
+
     /// <summary>
     /// When specified, only a signature is produced instead of encrypting
     /// the input. This parameter is automatically implied when using the
@@ -126,21 +171,34 @@ public class CmdletProtectPGP : PSCmdlet {
     public SwitchParameter SignOnly { get; set; }
 
     /// <summary>
+    /// Creates a clear-signed message that remains human readable.
+    /// </summary>
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFolder")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignFile")]
+    [Parameter(Mandatory = true, ParameterSetName = "ClearSignString")]
+    public SwitchParameter ClearSign { get; set; }
+
+    /// <summary>
     /// Encrypts or signs input data based on the selected
     /// parameter set and writes results to files or the pipeline.
     /// </summary>
     protected override void ProcessRecord() {
+        List<Stream> publicKeyStreams = new();
+        Stream signKeyStream = null;
         try {
             bool signOnlyMode = SignOnly.IsPresent || ParameterSetName.StartsWith("Sign", System.StringComparison.OrdinalIgnoreCase);
+            bool clearSignMode = ClearSign.IsPresent || ParameterSetName.StartsWith("ClearSign", System.StringComparison.OrdinalIgnoreCase);
+            bool symmetricMode = ParameterSetName.StartsWith("Symmetric", System.StringComparison.OrdinalIgnoreCase);
+            Dictionary<string, string> headers = HeaderHelper.ToDictionary(Headers);
 
-            var publicKeys = new List<FileInfo>();
-            if (!signOnlyMode) {
+            var publicKeys = new List<string>();
+            if (!signOnlyMode && !clearSignMode && !symmetricMode) {
                 foreach (var path in FilePathPublic) {
                     string resolved = PathResolver.Resolve(this, path);
                     if (File.Exists(resolved)) {
                         DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
                         KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
-                        publicKeys.Add(new FileInfo(resolved));
+                        publicKeys.Add(resolved);
                     } else {
                         ErrorActionHelper.WriteErrorOrWarning(
                             this,
@@ -159,53 +217,93 @@ public class CmdletProtectPGP : PSCmdlet {
                 KeyExpirationHelper.WarnIfExpired(this, SignKey.FullName, expiration);
             }
 
-            EncryptionKeys encryptionKeys = signOnlyMode
-                ? new EncryptionKeys(SignKey, SignPassword)
+            foreach (string publicKeyPath in publicKeys) {
+                publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKeyPath));
+            }
+
+            if (SignKey != null) {
+                signKeyStream = KeyMaterialHelper.OpenRead(SignKey.FullName);
+            }
+
+            EncryptionKeys encryptionKeys = symmetricMode
+                ? new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase))
+                : signOnlyMode || clearSignMode
+                ? new EncryptionKeys(signKeyStream, SignPassword)
                 : SignKey != null
-                    ? new EncryptionKeys(publicKeys, SignKey, SignPassword)
-                    : new EncryptionKeys(publicKeys);
+                    ? new EncryptionKeys(publicKeyStreams, signKeyStream, SignPassword)
+                    : new EncryptionKeys(publicKeyStreams);
             var pgp = new PGP(encryptionKeys);
 
             PGPConfigurator.Configure(pgp, HashAlgorithm, CompressionAlgorithm, FileType, PgpSignatureType, PublicKeyAlgorithm, SymmetricKeyAlgorithm);
 
-            if (ParameterSetName == "Folder" || ParameterSetName == "SignFolder") {
+            if (ParameterSetName == "Folder" || ParameterSetName == "SignFolder" || ParameterSetName == "ClearSignFolder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
                 foreach (var file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
-                    string extension = signOnlyMode ? ".sig" : ".pgp";
+                    string extension = clearSignMode ? ".asc" : signOnlyMode ? ".sig" : ".pgp";
                     string outputFile = !string.IsNullOrEmpty(OutputFolderPath)
                         ? Path.Combine(PathResolver.Resolve(this, OutputFolderPath), Path.GetFileName(file) + extension)
                         : file + extension;
 
-                    if (signOnlyMode) {
-                        pgp.SignFile(new FileInfo(file), new FileInfo(outputFile));
+                    if (clearSignMode) {
+                        pgp.ClearSignFile(new FileInfo(file), new FileInfo(outputFile), headers);
+                    } else if (signOnlyMode) {
+                        pgp.SignFile(new FileInfo(file), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
                     } else if (SignKey != null) {
-                        pgp.EncryptFileAndSign(new FileInfo(file), new FileInfo(outputFile));
+                        pgp.EncryptFileAndSign(new FileInfo(file), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                     } else {
-                        pgp.EncryptFile(new FileInfo(file), new FileInfo(outputFile));
+                        pgp.EncryptFile(new FileInfo(file), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                     }
                 }
-            } else if (ParameterSetName == "File" || ParameterSetName == "SignFile") {
+            } else if (ParameterSetName == "File" || ParameterSetName == "SignFile" || ParameterSetName == "ClearSignFile") {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
-                string extension = signOnlyMode ? ".sig" : ".pgp";
+                string extension = clearSignMode ? ".asc" : signOnlyMode ? ".sig" : ".pgp";
                 string outputFile = !string.IsNullOrEmpty(OutFilePath) ? PathResolver.Resolve(this, OutFilePath) : resolvedFile + extension;
 
-                if (signOnlyMode) {
-                    pgp.SignFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                if (clearSignMode) {
+                    pgp.ClearSignFile(new FileInfo(resolvedFile), new FileInfo(outputFile), headers);
+                } else if (signOnlyMode) {
+                    pgp.SignFile(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
                 } else if (SignKey != null) {
-                    pgp.EncryptFileAndSign(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                    pgp.EncryptFileAndSign(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                 } else {
-                    pgp.EncryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                    pgp.EncryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                 }
-            } else if (ParameterSetName == "String" || ParameterSetName == "SignString") {
-                string result = signOnlyMode
-                    ? pgp.SignArmoredString(String)
+            } else if (ParameterSetName == "String" || ParameterSetName == "SignString" || ParameterSetName == "ClearSignString" || ParameterSetName == "SymmetricString") {
+                string result = clearSignMode
+                    ? pgp.ClearSignArmoredString(String, headers)
+                    : signOnlyMode
+                    ? pgp.SignArmoredString(String, LiteralFileName, headers, OldFormat.IsPresent)
                     : SignKey != null
-                        ? pgp.EncryptArmoredStringAndSign(String)
-                        : pgp.EncryptArmoredString(String);
+                        ? pgp.EncryptArmoredStringAndSign(String, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent)
+                        : pgp.EncryptArmoredString(String, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                 WriteObject(result);
+            } else if (ParameterSetName == "SymmetricFolder" || ParameterSetName == "SymmetricFile") {
+                string resolvedFile = ParameterSetName == "SymmetricFile" ? PathResolver.Resolve(this, FilePath) : null;
+                if (ParameterSetName == "SymmetricFolder") {
+                    string resolvedFolder = PathResolver.Resolve(this, FolderPath);
+                    foreach (var file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
+                        string outputFile = !string.IsNullOrEmpty(OutputFolderPath)
+                            ? Path.Combine(PathResolver.Resolve(this, OutputFolderPath), Path.GetFileName(file) + ".pgp")
+                            : file + ".pgp";
+                        pgp.EncryptFile(new FileInfo(file), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
+                    }
+                } else {
+                    string outputFile = !string.IsNullOrEmpty(OutFilePath) ? PathResolver.Resolve(this, OutFilePath) : resolvedFile + ".pgp";
+                    pgp.EncryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
+                }
             }
         } catch (Exception ex) {
-            WriteError(new ErrorRecord(ex, "ProtectPGPFailed", ErrorCategory.NotSpecified, null));
+            string keyPath = SignKey?.FullName;
+            if (keyPath is null && FilePathPublic != null && FilePathPublic.Length > 0) {
+                keyPath = FilePathPublic[0];
+            }
+
+            WriteError(new ErrorRecord(PgpExceptionHelper.Normalize(ex, keyPath), "ProtectPGPFailed", ErrorCategory.NotSpecified, null));
+        } finally {
+            signKeyStream?.Dispose();
+            foreach (Stream stream in publicKeyStreams) {
+                stream.Dispose();
+            }
         }
     }
 }

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -16,22 +16,32 @@ namespace PSPGP;
 /// </para>
 /// <example>
 /// <code>
-/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
+/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
+/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String "Sensitive text"
+/// Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String "Sensitive text"
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP.asc -SignPassword 'secret' -String "Signed content"
+/// Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'Sensitive text'
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Signed content"
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Human readable signed content"
 /// </code>
 /// </example>
 /// </summary>

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -7,6 +7,7 @@ using System.Management.Automation;
 namespace PSPGP;
 /// <summary>
 /// <para>Verifies PGP signatures for files, folders or strings.</para>
+/// </summary>
 /// <example>
 /// <code>
 /// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString
@@ -27,7 +28,6 @@ namespace PSPGP;
 /// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString -ThrowIfEncrypted
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet(VerbsDiagnostic.Test, "PGP", DefaultParameterSetName = "File")]
 [OutputType(typeof(VerificationResult))]
 public class CmdletTestPGP : PSCmdlet {

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -47,6 +47,14 @@ public class CmdletTestPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "String")]
     public string String { get; set; }
 
+    /// <summary>Throws when encrypted content is passed to verify methods.</summary>
+    [Parameter]
+    public SwitchParameter ThrowIfEncrypted { get; set; }
+
+    /// <summary>Verifies clear-signed content instead of detached/regular signatures.</summary>
+    [Parameter]
+    public SwitchParameter ClearSigned { get; set; }
+
     /// <summary>
     /// Validates signatures for files, folders or strings
     /// using the provided public keys.
@@ -78,16 +86,19 @@ public class CmdletTestPGP : PSCmdlet {
                     string error = string.Empty;
                     string signer = null;
                     foreach (var key in publicKeys) {
-                        var encryptionKeys = new EncryptionKeys(new FileInfo(key));
-                        var pgp = new PGP(encryptionKeys);
                         try {
-                            status = pgp.VerifyFile(new FileInfo(file));
+                            using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
+                            var encryptionKeys = new EncryptionKeys(publicKeyStream);
+                            var pgp = new PGP(encryptionKeys);
+                            status = ClearSigned.IsPresent
+                                ? pgp.VerifyClearFile(new FileInfo(file))
+                                : pgp.VerifyFile(new FileInfo(file), ThrowIfEncrypted.IsPresent);
                             if (status) {
                                 signer = key;
                                 break;
                             }
                         } catch (Exception ex) {
-                            error = ex.Message;
+                            error = PgpExceptionHelper.Normalize(ex, key).Message;
                         }
                     }
                     var result = new VerificationResult {
@@ -104,16 +115,19 @@ public class CmdletTestPGP : PSCmdlet {
                 string error = string.Empty;
                 string signer = null;
                 foreach (var key in publicKeys) {
-                    var encryptionKeys = new EncryptionKeys(new FileInfo(key));
-                    var pgp = new PGP(encryptionKeys);
                     try {
-                        status = pgp.VerifyFile(new FileInfo(resolvedFile));
+                        using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
+                        var encryptionKeys = new EncryptionKeys(publicKeyStream);
+                        var pgp = new PGP(encryptionKeys);
+                        status = ClearSigned.IsPresent
+                            ? pgp.VerifyClearFile(new FileInfo(resolvedFile))
+                            : pgp.VerifyFile(new FileInfo(resolvedFile), ThrowIfEncrypted.IsPresent);
                         if (status) {
                             signer = key;
                             break;
                         }
                     } catch (Exception ex) {
-                        error = ex.Message;
+                        error = PgpExceptionHelper.Normalize(ex, key).Message;
                     }
                 }
                 var result = new VerificationResult {
@@ -128,15 +142,20 @@ public class CmdletTestPGP : PSCmdlet {
                 string error = string.Empty;
                 string signer = null;
                 foreach (var key in publicKeys) {
-                    var encryptionKeys = new EncryptionKeys(new FileInfo(key));
-                    var pgp = new PGP(encryptionKeys);
                     try {
-                        pgp.VerifyArmoredString(String);
+                        using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
+                        var encryptionKeys = new EncryptionKeys(publicKeyStream);
+                        var pgp = new PGP(encryptionKeys);
+                        if (ClearSigned.IsPresent) {
+                            pgp.VerifyClearArmoredString(String);
+                        } else {
+                            pgp.VerifyArmoredString(String, ThrowIfEncrypted.IsPresent);
+                        }
                         status = true;
                         signer = key;
                         break;
                     } catch (Exception ex) {
-                        error = ex.Message;
+                        error = PgpExceptionHelper.Normalize(ex, key).Message;
                     }
                 }
                 var result = new VerificationResult {

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -9,12 +9,22 @@ namespace PSPGP;
 /// <para>Verifies PGP signatures for files, folders or strings.</para>
 /// <example>
 /// <code>
-/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -String $ProtectedString
+/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP.asc -FolderPath $PSScriptRoot\Encoded
+/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Encoded
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString -ThrowIfEncrypted
 /// </code>
 /// </example>
 /// </summary>

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -156,14 +156,13 @@ public class CmdletTestPGP : PSCmdlet {
                         using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
                         var encryptionKeys = new EncryptionKeys(publicKeyStream);
                         var pgp = new PGP(encryptionKeys);
-                        if (ClearSigned.IsPresent) {
-                            pgp.VerifyClearArmoredString(String);
-                        } else {
-                            pgp.VerifyArmoredString(String, ThrowIfEncrypted.IsPresent);
+                        status = ClearSigned.IsPresent
+                            ? pgp.VerifyClearArmoredString(String)
+                            : pgp.VerifyArmoredString(String, ThrowIfEncrypted.IsPresent);
+                        if (status) {
+                            signer = key;
+                            break;
                         }
-                        status = true;
-                        signer = key;
-                        break;
                     } catch (Exception ex) {
                         error = PgpExceptionHelper.Normalize(ex, key).Message;
                     }

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -8,6 +8,7 @@ using System.Text;
 namespace PSPGP;
 /// <summary>
 /// <para>Removes PGP encryption from files or strings using a private key or symmetric passphrase.</para>
+/// </summary>
 /// <example>
 /// <code>
 /// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
@@ -28,7 +29,6 @@ namespace PSPGP;
 /// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'secret' -String $Encrypted -Verify
 /// </code>
 /// </example>
-/// </summary>
 [Cmdlet("Unprotect", "PGP", DefaultParameterSetName = "FolderClearText")]
 public class CmdletUnprotectPGP : PSCmdlet {
     /// <summary>Private key file used to decrypt data.</summary>

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -24,11 +24,6 @@ namespace PSPGP;
 /// Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $Encrypted
 /// </code>
 /// </example>
-/// <example>
-/// <code>
-/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'secret' -String $Encrypted -Verify
-/// </code>
-/// </example>
 [Cmdlet("Unprotect", "PGP", DefaultParameterSetName = "FolderClearText")]
 public class CmdletUnprotectPGP : PSCmdlet {
     /// <summary>Private key file used to decrypt data.</summary>
@@ -46,7 +41,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public string[] FilePathPrivate { get; set; }
 
-    /// <summary>Public key files used when verifying signed encrypted content.</summary>
+    /// <summary>Public key files reserved for signed-and-encrypted verification workflows.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
@@ -119,7 +114,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public string String { get; set; }
 
-    /// <summary>Decrypts and verifies encrypted signed content.</summary>
+    /// <summary>Reserved for future signed-and-encrypted verification support.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
@@ -133,11 +128,17 @@ public class CmdletUnprotectPGP : PSCmdlet {
     /// and writes the decrypted data to disk or the pipeline.
     /// </summary>
     protected override void ProcessRecord() {
+        bool verifyMode = ParameterSetName.IndexOf("Verify", System.StringComparison.OrdinalIgnoreCase) >= 0;
+        if (verifyMode) {
+            var exception = new NotSupportedException(
+                "Unprotect-PGP -Verify is temporarily disabled. PgpCore 7.0.0 does not perform trustworthy cryptographic verification in its DecryptAndVerify methods, so PSPGP fails closed rather than report a potentially forged message as verified.");
+            ThrowTerminatingError(new ErrorRecord(exception, "DecryptVerifyUnsupported", ErrorCategory.NotImplemented, null));
+            return;
+        }
+
         try {
             var resolvedPrivates = new List<string>();
             bool symmetricMode = ParameterSetName.EndsWith("Symmetric", System.StringComparison.OrdinalIgnoreCase);
-            bool verifyMode = ParameterSetName.IndexOf("Verify", System.StringComparison.OrdinalIgnoreCase) >= 0;
-            var resolvedPublics = new List<string>();
             if (!symmetricMode) {
                 foreach (var path in FilePathPrivate) {
                     string resolved = PathResolver.Resolve(this, path);
@@ -154,25 +155,6 @@ public class CmdletUnprotectPGP : PSCmdlet {
                     DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
                     KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
                     resolvedPrivates.Add(resolved);
-                }
-            }
-
-            if (verifyMode) {
-                foreach (var path in FilePathPublic) {
-                    string resolved = PathResolver.Resolve(this, path);
-                    if (!File.Exists(resolved)) {
-                        ErrorActionHelper.WriteErrorOrWarning(
-                            this,
-                            new FileNotFoundException($"Public key doesn't exist {resolved}"),
-                            "PublicKeyNotFound",
-                            ErrorCategory.InvalidArgument,
-                            resolved,
-                            $"Public key doesn't exist {resolved}");
-                        return;
-                    }
-                    DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
-                    KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
-                    resolvedPublics.Add(resolved);
                 }
             }
 
@@ -208,28 +190,11 @@ public class CmdletUnprotectPGP : PSCmdlet {
                             foreach (var key in resolvedPrivates) {
                                 try {
                                     using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                    List<Stream> publicKeyStreams = new();
-                                    try {
-                                        foreach (string publicKey in resolvedPublics) {
-                                            publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
-                                        }
-
-                                        var encryptionKeys = verifyMode
-                                            ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
-                                            : new EncryptionKeys(privateKeyStream, password);
-                                        var pgp = new PGP(encryptionKeys);
-                                        if (verifyMode) {
-                                            pgp.DecryptFileAndVerify(new FileInfo(file), new FileInfo(outputFile));
-                                        } else {
-                                            pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
-                                        }
-                                        decrypted = true;
-                                        break;
-                                    } finally {
-                                        foreach (Stream publicKeyStream in publicKeyStreams) {
-                                            publicKeyStream.Dispose();
-                                        }
-                                    }
+                                    var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
+                                    var pgp = new PGP(encryptionKeys);
+                                    pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+                                    decrypted = true;
+                                    break;
                                 } catch (Exception ex) {
                                     lastError = PgpExceptionHelper.Normalize(ex, key);
                                 }
@@ -264,28 +229,11 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         foreach (var key in resolvedPrivates) {
                             try {
                                 using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                List<Stream> publicKeyStreams = new();
-                                try {
-                                    foreach (string publicKey in resolvedPublics) {
-                                        publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
-                                    }
-
-                                    var encryptionKeys = verifyMode
-                                        ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
-                                        : new EncryptionKeys(privateKeyStream, password);
-                                    var pgp = new PGP(encryptionKeys);
-                                    if (verifyMode) {
-                                        pgp.DecryptFileAndVerify(new FileInfo(resolvedFile), new FileInfo(outputFile));
-                                    } else {
-                                        pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
-                                    }
-                                    decrypted = true;
-                                    break;
-                                } finally {
-                                    foreach (Stream publicKeyStream in publicKeyStreams) {
-                                        publicKeyStream.Dispose();
-                                    }
-                                }
+                                var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
+                                var pgp = new PGP(encryptionKeys);
+                                pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                                decrypted = true;
+                                break;
                             } catch (Exception ex) {
                                 lastError = PgpExceptionHelper.Normalize(ex, key);
                             }
@@ -317,26 +265,11 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         foreach (var key in resolvedPrivates) {
                             try {
                                 using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                List<Stream> publicKeyStreams = new();
-                                try {
-                                    foreach (string publicKey in resolvedPublics) {
-                                        publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
-                                    }
-
-                                    var encryptionKeys = verifyMode
-                                        ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
-                                        : new EncryptionKeys(privateKeyStream, password);
-                                    var pgp = new PGP(encryptionKeys);
-                                    result = verifyMode
-                                        ? pgp.DecryptArmoredStringAndVerify(String)
-                                        : pgp.DecryptArmoredString(String);
-                                    decrypted = true;
-                                    break;
-                                } finally {
-                                    foreach (Stream publicKeyStream in publicKeyStreams) {
-                                        publicKeyStream.Dispose();
-                                    }
-                                }
+                                var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
+                                var pgp = new PGP(encryptionKeys);
+                                result = pgp.DecryptArmoredString(String);
+                                decrypted = true;
+                                break;
                             } catch (Exception ex) {
                                 lastError = PgpExceptionHelper.Normalize(ex, key);
                             }

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Management.Automation;
+using System.Text;
 
 namespace PSPGP;
 /// <summary>
@@ -27,44 +28,95 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "FileClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "StringClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "StringCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public string[] FilePathPrivate { get; set; }
+
+    /// <summary>Public key files used when verifying signed encrypted content.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
+    public string[] FilePathPublic { get; set; }
+
+    /// <summary>Passphrase used for symmetric decryption.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "FolderSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringSymmetric")]
+    public string SymmetricPassphrase { get; set; }
 
     /// <summary>Password protecting the private key.</summary>
     [Parameter(ParameterSetName = "FolderClearText")]
     [Parameter(ParameterSetName = "FileClearText")]
     [Parameter(ParameterSetName = "StringClearText")]
+    [Parameter(ParameterSetName = "FolderVerifyClearText")]
+    [Parameter(ParameterSetName = "FileVerifyClearText")]
+    [Parameter(ParameterSetName = "StringVerifyClearText")]
     public string Password { get; set; }
 
     /// <summary>Credential object with password for the private key.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FileCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FolderCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "StringCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public PSCredential Credential { get; set; }
 
     /// <summary>Folder containing encrypted files.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FolderCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FolderClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
     public string FolderPath { get; set; }
 
     /// <summary>Destination folder for decrypted output.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FolderCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FolderClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
     public string OutputFolderPath { get; set; }
 
     /// <summary>Encrypted file to decrypt.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FileCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FileClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyClearText")]
     public string FilePath { get; set; }
 
     /// <summary>Output file path for decrypted data.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "FileCredential")]
     [Parameter(Mandatory = true, ParameterSetName = "FileClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyClearText")]
     public string OutFilePath { get; set; }
 
     /// <summary>Encrypted text to decrypt.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "StringClearText")]
     [Parameter(Mandatory = true, ParameterSetName = "StringCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringSymmetric")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public string String { get; set; }
+
+    /// <summary>Decrypts and verifies encrypted signed content.</summary>
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FolderVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyCredential")]
+    [Parameter(Mandatory = true, ParameterSetName = "FileVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyClearText")]
+    [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
+    public SwitchParameter Verify { get; set; }
 
     /// <summary>
     /// Decrypts files or strings using the supplied private keys
@@ -73,21 +125,45 @@ public class CmdletUnprotectPGP : PSCmdlet {
     protected override void ProcessRecord() {
         try {
             var resolvedPrivates = new List<string>();
-            foreach (var path in FilePathPrivate) {
-                string resolved = PathResolver.Resolve(this, path);
-                if (!File.Exists(resolved)) {
-                    ErrorActionHelper.WriteErrorOrWarning(
-                        this,
-                        new FileNotFoundException($"Private key doesn't exist {resolved}"),
-                        "PrivateKeyNotFound",
-                        ErrorCategory.InvalidArgument,
-                        resolved,
-                        $"Private key doesn't exist {resolved}");
-                    return;
+            bool symmetricMode = ParameterSetName.EndsWith("Symmetric", System.StringComparison.OrdinalIgnoreCase);
+            bool verifyMode = ParameterSetName.IndexOf("Verify", System.StringComparison.OrdinalIgnoreCase) >= 0;
+            var resolvedPublics = new List<string>();
+            if (!symmetricMode) {
+                foreach (var path in FilePathPrivate) {
+                    string resolved = PathResolver.Resolve(this, path);
+                    if (!File.Exists(resolved)) {
+                        ErrorActionHelper.WriteErrorOrWarning(
+                            this,
+                            new FileNotFoundException($"Private key doesn't exist {resolved}"),
+                            "PrivateKeyNotFound",
+                            ErrorCategory.InvalidArgument,
+                            resolved,
+                            $"Private key doesn't exist {resolved}");
+                        return;
+                    }
+                    DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                    KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
+                    resolvedPrivates.Add(resolved);
                 }
-                DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
-                KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
-                resolvedPrivates.Add(resolved);
+            }
+
+            if (verifyMode) {
+                foreach (var path in FilePathPublic) {
+                    string resolved = PathResolver.Resolve(this, path);
+                    if (!File.Exists(resolved)) {
+                        ErrorActionHelper.WriteErrorOrWarning(
+                            this,
+                            new FileNotFoundException($"Public key doesn't exist {resolved}"),
+                            "PublicKeyNotFound",
+                            ErrorCategory.InvalidArgument,
+                            resolved,
+                            $"Public key doesn't exist {resolved}");
+                        return;
+                    }
+                    DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                    KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
+                    resolvedPublics.Add(resolved);
+                }
             }
 
             string password = Password;
@@ -109,15 +185,44 @@ public class CmdletUnprotectPGP : PSCmdlet {
 
                         bool decrypted = false;
                         Exception lastError = null;
-                        foreach (var key in resolvedPrivates) {
+                        if (symmetricMode) {
                             try {
-                                var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                                var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                                 var pgp = new PGP(encryptionKeys);
                                 pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
                                 decrypted = true;
-                                break;
                             } catch (Exception ex) {
-                                lastError = ex;
+                                lastError = PgpExceptionHelper.Normalize(ex);
+                            }
+                        } else {
+                            foreach (var key in resolvedPrivates) {
+                                try {
+                                    using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
+                                    List<Stream> publicKeyStreams = new();
+                                    try {
+                                        foreach (string publicKey in resolvedPublics) {
+                                            publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
+                                        }
+
+                                        var encryptionKeys = verifyMode
+                                            ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
+                                            : new EncryptionKeys(privateKeyStream, password);
+                                        var pgp = new PGP(encryptionKeys);
+                                        if (verifyMode) {
+                                            pgp.DecryptFileAndVerify(new FileInfo(file), new FileInfo(outputFile));
+                                        } else {
+                                            pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+                                        }
+                                        decrypted = true;
+                                        break;
+                                    } finally {
+                                        foreach (Stream publicKeyStream in publicKeyStreams) {
+                                            publicKeyStream.Dispose();
+                                        }
+                                    }
+                                } catch (Exception ex) {
+                                    lastError = PgpExceptionHelper.Normalize(ex, key);
+                                }
                             }
                         }
 
@@ -136,15 +241,44 @@ public class CmdletUnprotectPGP : PSCmdlet {
 
                     bool decrypted = false;
                     Exception lastError = null;
-                    foreach (var key in resolvedPrivates) {
+                    if (symmetricMode) {
                         try {
-                            var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                            var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                             var pgp = new PGP(encryptionKeys);
                             pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
                             decrypted = true;
-                            break;
                         } catch (Exception ex) {
-                            lastError = ex;
+                            lastError = PgpExceptionHelper.Normalize(ex);
+                        }
+                    } else {
+                        foreach (var key in resolvedPrivates) {
+                            try {
+                                using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
+                                List<Stream> publicKeyStreams = new();
+                                try {
+                                    foreach (string publicKey in resolvedPublics) {
+                                        publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
+                                    }
+
+                                    var encryptionKeys = verifyMode
+                                        ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
+                                        : new EncryptionKeys(privateKeyStream, password);
+                                    var pgp = new PGP(encryptionKeys);
+                                    if (verifyMode) {
+                                        pgp.DecryptFileAndVerify(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                                    } else {
+                                        pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                                    }
+                                    decrypted = true;
+                                    break;
+                                } finally {
+                                    foreach (Stream publicKeyStream in publicKeyStreams) {
+                                        publicKeyStream.Dispose();
+                                    }
+                                }
+                            } catch (Exception ex) {
+                                lastError = PgpExceptionHelper.Normalize(ex, key);
+                            }
                         }
                     }
 
@@ -160,15 +294,42 @@ public class CmdletUnprotectPGP : PSCmdlet {
                     bool decrypted = false;
                     string result = null;
                     Exception lastError = null;
-                    foreach (var key in resolvedPrivates) {
+                    if (symmetricMode) {
                         try {
-                            var encryptionKeys = new EncryptionKeys(File.ReadAllText(key), password);
+                            var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                             var pgp = new PGP(encryptionKeys);
                             result = pgp.DecryptArmoredString(String);
                             decrypted = true;
-                            break;
                         } catch (Exception ex) {
-                            lastError = ex;
+                            lastError = PgpExceptionHelper.Normalize(ex);
+                        }
+                    } else {
+                        foreach (var key in resolvedPrivates) {
+                            try {
+                                using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
+                                List<Stream> publicKeyStreams = new();
+                                try {
+                                    foreach (string publicKey in resolvedPublics) {
+                                        publicKeyStreams.Add(KeyMaterialHelper.OpenRead(publicKey));
+                                    }
+
+                                    var encryptionKeys = verifyMode
+                                        ? new EncryptionKeys(publicKeyStreams, privateKeyStream, password)
+                                        : new EncryptionKeys(privateKeyStream, password);
+                                    var pgp = new PGP(encryptionKeys);
+                                    result = verifyMode
+                                        ? pgp.DecryptArmoredStringAndVerify(String)
+                                        : pgp.DecryptArmoredString(String);
+                                    decrypted = true;
+                                    break;
+                                } finally {
+                                    foreach (Stream publicKeyStream in publicKeyStreams) {
+                                        publicKeyStream.Dispose();
+                                    }
+                                }
+                            } catch (Exception ex) {
+                                lastError = PgpExceptionHelper.Normalize(ex, key);
+                            }
                         }
                     }
 

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -7,15 +7,25 @@ using System.Text;
 
 namespace PSPGP;
 /// <summary>
-/// <para>Removes PGP encryption from files or strings using a private key.</para>
+/// <para>Removes PGP encryption from files or strings using a private key or symmetric passphrase.</para>
 /// <example>
 /// <code>
-/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'secret' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
+/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
 /// </code>
 /// </example>
 /// <example>
 /// <code>
-/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP.asc -Password 'secret' -String $Encrypted
+/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -String $Encrypted
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $Encrypted
+/// </code>
+/// </example>
+/// <example>
+/// <code>
+/// Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'secret' -String $Encrypted -Verify
 /// </code>
 /// </example>
 /// </summary>

--- a/Sources/PSPGP/HeaderHelper.cs
+++ b/Sources/PSPGP/HeaderHelper.cs
@@ -1,0 +1,24 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace PSPGP;
+
+internal static class HeaderHelper {
+    internal static Dictionary<string, string> ToDictionary(Hashtable headers) {
+        if (headers == null || headers.Count == 0) {
+            return null;
+        }
+
+        var dictionary = new Dictionary<string, string>();
+        foreach (DictionaryEntry entry in headers) {
+            string key = entry.Key?.ToString();
+            if (string.IsNullOrEmpty(key)) {
+                continue;
+            }
+
+            dictionary[key] = entry.Value?.ToString() ?? string.Empty;
+        }
+
+        return dictionary;
+    }
+}

--- a/Sources/PSPGP/KeyExpirationHelper.cs
+++ b/Sources/PSPGP/KeyExpirationHelper.cs
@@ -16,7 +16,7 @@ internal static class KeyExpirationHelper {
     /// <param name="filePath">Path to the PGP key.</param>
     /// <returns>The expiration date if available.</returns>
     internal static DateTime? GetExpiration(string filePath) {
-        using FileStream keyStream = File.OpenRead(filePath);
+        using Stream keyStream = KeyMaterialHelper.OpenRead(filePath);
         using Stream decoderStream = PgpUtilities.GetDecoderStream(keyStream);
         PgpObjectFactory factory = new(decoderStream);
         PgpPublicKey publicKey = null;

--- a/Sources/PSPGP/KeyMaterialHelper.cs
+++ b/Sources/PSPGP/KeyMaterialHelper.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Text;
+
+namespace PSPGP;
+
+internal static class KeyMaterialHelper {
+    private const string BeginMarker = "-----BEGIN PGP ";
+    private const string EndMarker = "-----END PGP ";
+
+    internal static Stream OpenRead(string filePath) {
+        byte[] bytes = File.ReadAllBytes(filePath);
+        return new MemoryStream(Normalize(bytes), writable: false);
+    }
+
+    internal static byte[] Normalize(byte[] bytes) {
+        if (TryNormalizeArmoredKey(bytes, out byte[] normalized)) {
+            return normalized;
+        }
+
+        return bytes;
+    }
+
+    private static bool TryNormalizeArmoredKey(byte[] bytes, out byte[] normalized) {
+        string text = DecodeText(bytes);
+        int begin = text.IndexOf(BeginMarker, StringComparison.Ordinal);
+        if (begin < 0) {
+            normalized = null;
+            return false;
+        }
+
+        int end = text.LastIndexOf(EndMarker, StringComparison.Ordinal);
+        if (end < begin) {
+            normalized = null;
+            return false;
+        }
+
+        int endOfLine = text.IndexOfAny(new[] { '\r', '\n' }, end);
+        string block = (endOfLine >= 0 ? text.Substring(begin, endOfLine - begin) : text.Substring(begin)).Trim();
+        normalized = Encoding.UTF8.GetBytes(block);
+        return true;
+    }
+
+    private static string DecodeText(byte[] bytes) {
+        if (HasPrefix(bytes, 0xEF, 0xBB, 0xBF)) {
+            return Encoding.UTF8.GetString(bytes, 3, bytes.Length - 3);
+        }
+
+        if (HasPrefix(bytes, 0xFF, 0xFE)) {
+            return Encoding.Unicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        if (HasPrefix(bytes, 0xFE, 0xFF)) {
+            return Encoding.BigEndianUnicode.GetString(bytes, 2, bytes.Length - 2);
+        }
+
+        return Encoding.UTF8.GetString(bytes);
+    }
+
+    private static bool HasPrefix(byte[] bytes, params byte[] prefix) {
+        if (bytes.Length < prefix.Length) {
+            return false;
+        }
+
+        for (int i = 0; i < prefix.Length; i++) {
+            if (bytes[i] != prefix[i]) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/Sources/PSPGP/PGPInspectInfo.cs
+++ b/Sources/PSPGP/PGPInspectInfo.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Org.BouncyCastle.Bcpg;
+
+namespace PSPGP;
+
+/// <summary>
+/// Represents the metadata extracted from a PGP message.
+/// </summary>
+public class PGPInspectInfo {
+    /// <summary>Path of the inspected input when applicable.</summary>
+    public string SourcePath { get; set; }
+
+    /// <summary>Indicates whether the message is ASCII armored.</summary>
+    public bool IsArmored { get; set; }
+
+    /// <summary>Headers found in the armored message.</summary>
+    public Dictionary<string, string> MessageHeaders { get; set; }
+
+    /// <summary>Version header value when present.</summary>
+    public string Version { get; set; }
+
+    /// <summary>Comment header value when present.</summary>
+    public string Comment { get; set; }
+
+    /// <summary>Indicates whether the message is compressed.</summary>
+    public bool IsCompressed { get; set; }
+
+    /// <summary>Indicates whether the message is encrypted.</summary>
+    public bool IsEncrypted { get; set; }
+
+    /// <summary>Indicates whether the message is integrity protected.</summary>
+    public bool IsIntegrityProtected { get; set; }
+
+    /// <summary>Indicates whether the message is signed.</summary>
+    public bool IsSigned { get; set; }
+
+    /// <summary>Symmetric algorithm reported by the message.</summary>
+    public SymmetricKeyAlgorithmTag SymmetricKeyAlgorithm { get; set; }
+
+    /// <summary>Embedded file name reported by the message.</summary>
+    public string FileName { get; set; }
+
+    /// <summary>Embedded modification time reported by the message.</summary>
+    public System.DateTime ModificationDateTime { get; set; }
+}

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -11,7 +11,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="PgpCore" Version="6.5.2" />
+        <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
+        <PackageReference Include="PgpCore" Version="7.0.0" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -41,13 +41,12 @@
     </PropertyGroup>
 
     <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-    <!-- <ItemGroup>
-
+    <ItemGroup>
         <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-    </ItemGroup> -->
+    </ItemGroup>
 
     <!-- Copy help documentation to publish output after publish -->
     <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">

--- a/Sources/PSPGP/PgpExceptionHelper.cs
+++ b/Sources/PSPGP/PgpExceptionHelper.cs
@@ -1,0 +1,27 @@
+using System;
+using System.IO;
+
+namespace PSPGP;
+
+internal static class PgpExceptionHelper {
+    internal static Exception Normalize(Exception exception, string keyPath = null) {
+        string message = exception?.Message ?? string.Empty;
+
+        if (message.IndexOf("unknown packet type encountered: 20", StringComparison.OrdinalIgnoreCase) >= 0) {
+            return new NotSupportedException(
+                "The encrypted content appears to use OpenPGP AEAD (packet type 20), which the underlying PgpCore/BouncyCastle stack cannot decrypt yet. Re-encrypt the file without AEAD, or remove the AEAD preference from the key before creating new encrypted content.",
+                exception);
+        }
+
+        if (!string.IsNullOrEmpty(keyPath) &&
+            (message.IndexOf("invalid armor header", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             message.IndexOf("unknown object in stream", StringComparison.OrdinalIgnoreCase) >= 0 ||
+             message.IndexOf("Premature end of stream in PartialInputStream", StringComparison.OrdinalIgnoreCase) >= 0)) {
+            return new InvalidDataException(
+                $"The PGP key file '{keyPath}' could not be parsed. If it is ASCII-armored, re-export or save it as plain UTF-8 text without BOM or extra wrapper content.",
+                exception);
+        }
+
+        return exception;
+    }
+}

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -111,6 +111,26 @@
         $inspection.IsArmored | Should -Be $true
     }
 
+    It ' Inspect folder continues when one file cannot be inspected' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $inspectFolder = [io.path]::Combine($KeysDirectory, 'inspect-folder')
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'inspect-input.txt')
+        $signedFile = [io.path]::Combine($inspectFolder, 'signed.asc')
+        $encryptedFile = [io.path]::Combine($inspectFolder, 'encrypted.pgp')
+        New-Item -ItemType Directory -Path $inspectFolder -Force | Out-Null
+        Set-Content -Path $sourceFile -Value 'Inspect folder content' -NoNewline
+        Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $signedFile -ErrorAction Stop
+        Protect-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -OutFilePath $encryptedFile -ErrorAction Stop
+
+        $inspectErrors = @()
+        $results = Get-PGPInspect -FolderPath $inspectFolder -ErrorAction Continue -ErrorVariable +inspectErrors
+
+        $results.Count | Should -Be 1
+        $results[0].SourcePath | Should -Be $signedFile
+        $results[0].IsSigned | Should -Be $true
+        $inspectErrors.Count | Should -Be 1
+        $inspectErrors[0].Exception.Message | Should -Match 'Signed content inspection works'
+    }
+
     It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {
         $protected = Protect-PGP -FilePathPublic $KeyPublic -String 'Encrypted but unsigned'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $protected -ThrowIfEncrypted

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -67,6 +67,13 @@
         $result.Status | Should -Be $true
     }
 
+    It ' Clear sign verification fails with the wrong public key' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic1 } {
+        $clearSigned = Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Clear Signed Text'
+        $result = Test-PGP -FilePathPublic $KeyPublic -String $clearSigned -ClearSigned
+        $result.Status | Should -Be $false
+        $result.Signer | Should -BeNullOrEmpty
+    }
+
     It ' Clear sign and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt')
         $signedFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt.asc')
@@ -82,20 +89,19 @@
         $plain | Should -Be 'Symmetric Text'
     }
 
-    It ' Encrypt, sign, decrypt and verify string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
+    It ' Encrypt, sign, decrypt and verify string is blocked until upstream verification is trustworthy' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
         $protected = Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Decrypt and verify text'
-        $plain = Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -String $protected -Verify
-        $plain | Should -Be 'Decrypt and verify text'
+        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -String $protected -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*temporarily disabled*'
     }
 
-    It ' Encrypt, sign, decrypt and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+    It ' Encrypt, sign, decrypt and verify file is blocked until upstream verification is trustworthy' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt')
         $protectedFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt.pgp')
         $outputFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-output.txt')
         Set-Content -Path $sourceFile -Value 'Decrypt and verify file content' -NoNewline
         Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $protectedFile -ErrorAction Stop
-        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop } | Should -Not -Throw
-        Get-Content -Path $outputFile -Raw | Should -Be 'Decrypt and verify file content'
+        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*temporarily disabled*'
+        Test-Path -LiteralPath $outputFile | Should -Be $false
     }
 
     It ' Inspect signed string' -TestCases @{ KeyPrivate = $KeyPrivate } {

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -6,6 +6,8 @@
 
     $KeyPublic1 = [io.path]::Combine($KeysDirectory, 'PublicPGP1.asc')
     $KeyPrivate1 = [io.path]::Combine($KeysDirectory, 'PrivatePGP1.asc')
+    $KeyPublicBom = [io.path]::Combine($KeysDirectory, 'PublicPGP-Bom.asc')
+    $KeyPrivateBom = [io.path]::Combine($KeysDirectory, 'PrivatePGP-Bom.asc')
     [string] $Script:ProtectedString = ''
 
     BeforeAll {
@@ -57,6 +59,73 @@
         $signed = Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Signed Text'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $signed
         $result.Status | Should -Be $true
+    }
+
+    It ' Clear sign and verify string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
+        $clearSigned = Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Clear Signed Text'
+        $result = Test-PGP -FilePathPublic $KeyPublic -String $clearSigned -ClearSigned
+        $result.Status | Should -Be $true
+    }
+
+    It ' Clear sign and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt')
+        $signedFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt.asc')
+        Set-Content -Path $sourceFile -Value 'Clear signed file content' -NoNewline
+        Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $signedFile -ErrorAction Stop
+        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $signedFile -ClearSigned
+        $result.Status | Should -Be $true
+    }
+
+    It ' Encrypt and decrypt string symmetrically' {
+        $protected = Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'Symmetric Text'
+        $plain = Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $protected
+        $plain | Should -Be 'Symmetric Text'
+    }
+
+    It ' Encrypt, sign, decrypt and verify string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
+        $protected = Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Decrypt and verify text'
+        $plain = Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -String $protected -Verify
+        $plain | Should -Be 'Decrypt and verify text'
+    }
+
+    It ' Encrypt, sign, decrypt and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt')
+        $protectedFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt.pgp')
+        $outputFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-output.txt')
+        Set-Content -Path $sourceFile -Value 'Decrypt and verify file content' -NoNewline
+        Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $protectedFile -ErrorAction Stop
+        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop } | Should -Not -Throw
+        Get-Content -Path $outputFile -Raw | Should -Be 'Decrypt and verify file content'
+    }
+
+    It ' Inspect signed string' -TestCases @{ KeyPrivate = $KeyPrivate } {
+        $signed = Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Inspect me'
+        $inspection = Get-PGPInspect -String $signed
+        $inspection.IsSigned | Should -Be $true
+        $inspection.IsArmored | Should -Be $true
+    }
+
+    It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {
+        $protected = Protect-PGP -FilePathPublic $KeyPublic -String 'Encrypted but unsigned'
+        $result = Test-PGP -FilePathPublic $KeyPublic -String $protected -ThrowIfEncrypted
+        $result.Status | Should -Be $false
+        $result.Error | Should -Not -BeNullOrEmpty
+    }
+
+    It ' Encrypt file when public key is UTF-8 BOM encoded' -TestCases @{ KeyPublic = $KeyPublic; KeyPublicBom = $KeyPublicBom; KeysDirectory = $KeysDirectory } {
+        [System.IO.File]::WriteAllText($KeyPublicBom, [System.IO.File]::ReadAllText($KeyPublic), [System.Text.UTF8Encoding]::new($true))
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'bom-input.txt')
+        $encryptedFile = [io.path]::Combine($KeysDirectory, 'bom-input.txt.pgp')
+        Set-Content -Path $sourceFile -Value 'BOM tolerant encryption test' -NoNewline
+
+        { Protect-PGP -FilePathPublic $KeyPublicBom -FilePath $sourceFile -OutFilePath $encryptedFile -ErrorAction Stop } | Should -Not -Throw
+        Test-Path -LiteralPath $encryptedFile | Should -Be $true
+    }
+
+    It ' Decrypt string when private key is UTF-8 BOM encoded' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPrivateBom = $KeyPrivateBom; ProtectedString = $ProtectedString } {
+        [System.IO.File]::WriteAllText($KeyPrivateBom, [System.IO.File]::ReadAllText($KeyPrivate), [System.Text.UTF8Encoding]::new($true))
+        $String = Unprotect-PGP -FilePathPrivate $KeyPrivateBom -Password 'ZielonaMila9!' -String $Script:ProtectedString
+        $String | Should -Be "This is string to encrypt"
     }
 
     Context 'Error action preference' {

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -125,7 +125,7 @@
         $results = Get-PGPInspect -FolderPath $inspectFolder -ErrorAction Continue -ErrorVariable +inspectErrors
 
         $results.Count | Should -Be 1
-        $results[0].SourcePath | Should -Be $signedFile
+        [IO.Path]::GetFullPath($results[0].SourcePath) | Should -Be ([IO.Path]::GetFullPath($signedFile))
         $results[0].IsSigned | Should -Be $true
         $inspectErrors.Count | Should -Be 1
         $inspectErrors[0].Exception.Message | Should -Match 'Signed content inspection works'


### PR DESCRIPTION
## Summary
- add PgpCore parity features for symmetric encryption/decryption, clear-sign verification flows, and decrypt-and-verify flows
- harden key handling for BOM/encoding issues and improve user-facing PGP error messages
- add `Get-PGPInspect`, expose more PgpCore options, and refresh README/test coverage

## Why
PSPGP had moved the original function surface to compiled cmdlets, but it still lagged behind recent PgpCore capabilities and had a few rough edges around key parsing and advanced workflows. This closes the biggest local gaps so the module is usable end to end even if upstream PgpCore fixes take time.

## Notes
- encrypted-message inspection is still limited by an upstream PgpCore null-reference issue; PSPGP now reports that more clearly instead of surfacing a raw crash
- this PR intentionally fixes the PSPGP side first and does not depend on an upstream PgpCore change landing

## Validation
- `dotnet test Sources\\PSPGP.sln`
- `pwsh -NoProfile -File Tests\\PSPGP.Tests.ps1`
- manual smoke tests in PowerShell 7 and Windows PowerShell 5.1 for asymmetric, symmetric, clear-sign, and decrypt-and-verify flows