### PR TITLE
Upgrade PgpCore and restore decrypt verification

### DIFF
--- a/.github/workflows/test-powershell.yml
+++ b/.github/workflows/test-powershell.yml
@@ -79,6 +79,9 @@ jobs:
             - name: Install PowerShell modules
               run: |
                 Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)"
+                if (-not (Get-PSRepository -Name PSGallery -ErrorAction SilentlyContinue)) {
+                  Register-PSRepository -Default
+                }
                 Install-Module -Name Pester -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
                 Install-Module -Name PSWriteColor -Repository PSGallery -Force -SkipPublisherCheck -AllowClobber
               shell: powershell

--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -71,7 +71,7 @@
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -StartClean -UpdateWhenNew -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 

--- a/README.MD
+++ b/README.MD
@@ -151,15 +151,14 @@ $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -
 Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $Signature
 ```
 
-### Signed-and-encrypted verification status
+### Decrypt and verify signed-and-encrypted content
 
-`Unprotect-PGP -Verify` is currently disabled on purpose. `PgpCore` 7.0.0 does not perform trustworthy cryptographic verification in its `DecryptAndVerify` methods, so PSPGP fails closed instead of reporting potentially forged content as verified.
+```powershell
+$Protected = Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed and encrypted text'
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -Password 'ZielonaMila9!' -String $Protected -Verify
+```
 
-You can still:
-
-- encrypt and sign with `Protect-PGP`
-- verify detached or clear-signed content with `Test-PGP`
-- decrypt signed-and-encrypted content with `Unprotect-PGP` when you do not request `-Verify`
+When `-Verify` is used with file output, PSPGP writes decrypted content through a temporary file and only moves it to the requested output path after signature verification succeeds.
 
 ### Download and inspect public keys
 

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -128,7 +128,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
     /// and writes the decrypted data to disk or the pipeline.
     /// </summary>
     protected override void ProcessRecord() {
-        bool verifyMode = ParameterSetName.IndexOf("Verify", System.StringComparison.OrdinalIgnoreCase) >= 0;
+        bool verifyMode = Verify.IsPresent;
 
         try {
             var resolvedPrivates = new List<string>();

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -129,15 +129,10 @@ public class CmdletUnprotectPGP : PSCmdlet {
     /// </summary>
     protected override void ProcessRecord() {
         bool verifyMode = ParameterSetName.IndexOf("Verify", System.StringComparison.OrdinalIgnoreCase) >= 0;
-        if (verifyMode) {
-            var exception = new NotSupportedException(
-                "Unprotect-PGP -Verify is temporarily disabled. PgpCore 7.0.0 does not perform trustworthy cryptographic verification in its DecryptAndVerify methods, so PSPGP fails closed rather than report a potentially forged message as verified.");
-            ThrowTerminatingError(new ErrorRecord(exception, "DecryptVerifyUnsupported", ErrorCategory.NotImplemented, null));
-            return;
-        }
 
         try {
             var resolvedPrivates = new List<string>();
+            var resolvedPublics = new List<string>();
             bool symmetricMode = ParameterSetName.EndsWith("Symmetric", System.StringComparison.OrdinalIgnoreCase);
             if (!symmetricMode) {
                 foreach (var path in FilePathPrivate) {
@@ -155,6 +150,25 @@ public class CmdletUnprotectPGP : PSCmdlet {
                     DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
                     KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
                     resolvedPrivates.Add(resolved);
+                }
+            }
+
+            if (verifyMode) {
+                foreach (var path in FilePathPublic) {
+                    string resolved = PathResolver.Resolve(this, path);
+                    if (!File.Exists(resolved)) {
+                        ErrorActionHelper.WriteErrorOrWarning(
+                            this,
+                            new FileNotFoundException($"Public key doesn't exist {resolved}"),
+                            "PublicKeyNotFound",
+                            ErrorCategory.InvalidArgument,
+                            resolved,
+                            $"Public key doesn't exist {resolved}");
+                        return;
+                    }
+                    DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+                    KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
+                    resolvedPublics.Add(resolved);
                 }
             }
 
@@ -190,9 +204,18 @@ public class CmdletUnprotectPGP : PSCmdlet {
                             foreach (var key in resolvedPrivates) {
                                 try {
                                     using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                    var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
-                                    var pgp = new PGP(encryptionKeys);
-                                    pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+                                    List<Stream> publicKeyStreams = null;
+                                    try {
+                                        var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
+                                        var pgp = new PGP(encryptionKeys);
+                                        if (verifyMode) {
+                                            DecryptFileAndVerifyToOutput(pgp, file, outputFile);
+                                        } else {
+                                            pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
+                                        }
+                                    } finally {
+                                        DisposeStreams(publicKeyStreams);
+                                    }
                                     decrypted = true;
                                     break;
                                 } catch (Exception ex) {
@@ -229,9 +252,18 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         foreach (var key in resolvedPrivates) {
                             try {
                                 using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
-                                var pgp = new PGP(encryptionKeys);
-                                pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                                List<Stream> publicKeyStreams = null;
+                                try {
+                                    var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
+                                    var pgp = new PGP(encryptionKeys);
+                                    if (verifyMode) {
+                                        DecryptFileAndVerifyToOutput(pgp, resolvedFile, outputFile);
+                                    } else {
+                                        pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
+                                    }
+                                } finally {
+                                    DisposeStreams(publicKeyStreams);
+                                }
                                 decrypted = true;
                                 break;
                             } catch (Exception ex) {
@@ -265,9 +297,16 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         foreach (var key in resolvedPrivates) {
                             try {
                                 using var privateKeyStream = KeyMaterialHelper.OpenRead(key);
-                                var encryptionKeys = new EncryptionKeys(privateKeyStream, password);
-                                var pgp = new PGP(encryptionKeys);
-                                result = pgp.DecryptArmoredString(String);
+                                List<Stream> publicKeyStreams = null;
+                                try {
+                                    var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
+                                    var pgp = new PGP(encryptionKeys);
+                                    result = verifyMode
+                                        ? pgp.DecryptArmoredStringAndVerify(String)
+                                        : pgp.DecryptArmoredString(String);
+                                } finally {
+                                    DisposeStreams(publicKeyStreams);
+                                }
                                 decrypted = true;
                                 break;
                             } catch (Exception ex) {
@@ -288,5 +327,64 @@ public class CmdletUnprotectPGP : PSCmdlet {
         } catch (Exception ex) {
             WriteError(new ErrorRecord(ex, "UnprotectPGPFailed", ErrorCategory.NotSpecified, null));
         }
+    }
+
+    private static EncryptionKeys CreateEncryptionKeys(Stream privateKeyStream, string password, List<string> publicKeyPaths, bool verifyMode, out List<Stream> publicKeyStreams) {
+        publicKeyStreams = null;
+        if (!verifyMode) {
+            return new EncryptionKeys(privateKeyStream, password);
+        }
+
+        publicKeyStreams = OpenStreams(publicKeyPaths);
+        return new EncryptionKeys(publicKeyStreams, privateKeyStream, password);
+    }
+
+    private static List<Stream> OpenStreams(List<string> paths) {
+        var streams = new List<Stream>();
+        try {
+            foreach (string path in paths) {
+                streams.Add(KeyMaterialHelper.OpenRead(path));
+            }
+        } catch {
+            DisposeStreams(streams);
+            throw;
+        }
+
+        return streams;
+    }
+
+    private static void DisposeStreams(List<Stream> streams) {
+        if (streams == null) {
+            return;
+        }
+
+        foreach (Stream stream in streams) {
+            stream.Dispose();
+        }
+    }
+
+    private static void DecryptFileAndVerifyToOutput(PGP pgp, string inputFile, string outputFile) {
+        string tempOutputFile = GetTemporaryOutputFile(outputFile);
+        try {
+            pgp.DecryptFileAndVerify(new FileInfo(inputFile), new FileInfo(tempOutputFile));
+            if (File.Exists(outputFile)) {
+                File.Delete(outputFile);
+            }
+            File.Move(tempOutputFile, outputFile);
+        } finally {
+            if (File.Exists(tempOutputFile)) {
+                File.Delete(tempOutputFile);
+            }
+        }
+    }
+
+    private static string GetTemporaryOutputFile(string outputFile) {
+        string directory = Path.GetDirectoryName(outputFile);
+        string fileName = Path.GetFileName(outputFile);
+        if (string.IsNullOrEmpty(directory)) {
+            directory = Directory.GetCurrentDirectory();
+        }
+
+        return Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp");
     }
 }

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-        <PackageReference Include="PgpCore" Version="7.0.0" />
+        <PackageReference Include="PgpCore" Version="7.1.0" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -89,18 +89,34 @@
         $plain | Should -Be 'Symmetric Text'
     }
 
-    It ' Encrypt, sign, decrypt and verify string is blocked until upstream verification is trustworthy' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
+    It ' Encrypt, sign, decrypt and verify string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
         $protected = Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Decrypt and verify text'
-        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -String $protected -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*temporarily disabled*'
+        $plain = Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -String $protected -Verify -ErrorAction Stop
+        $plain | Should -Be 'Decrypt and verify text'
     }
 
-    It ' Encrypt, sign, decrypt and verify file is blocked until upstream verification is trustworthy' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+    It ' Encrypt, sign, decrypt and verify string rejects the wrong public key' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeyPublic1 = $KeyPublic1 } {
+        $protected = Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Decrypt and verify text'
+        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic1 -Password 'ZielonaMila9!' -String $protected -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*Failed to verify file*'
+    }
+
+    It ' Encrypt, sign, decrypt and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt')
         $protectedFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt.pgp')
         $outputFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-output.txt')
         Set-Content -Path $sourceFile -Value 'Decrypt and verify file content' -NoNewline
         Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $protectedFile -ErrorAction Stop
-        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*temporarily disabled*'
+        Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop
+        Get-Content -LiteralPath $outputFile -Raw | Should -Be 'Decrypt and verify file content'
+    }
+
+    It ' Encrypt, sign, decrypt and verify file rejects the wrong public key without writing output' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeyPublic1 = $KeyPublic1; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-wrong-key-input.txt')
+        $protectedFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-wrong-key-input.txt.pgp')
+        $outputFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-wrong-key-output.txt')
+        Set-Content -Path $sourceFile -Value 'Decrypt and verify wrong key file content' -NoNewline
+        Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $protectedFile -ErrorAction Stop
+        { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic1 -Password 'ZielonaMila9!' -FilePath $protectedFile -OutFilePath $outputFile -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*Failed to verify file*'
         Test-Path -LiteralPath $outputFile | Should -Be $false
     }
 

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -100,6 +100,12 @@
         { Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic1 -Password 'ZielonaMila9!' -String $protected -Verify -ErrorAction Stop } | Should -Throw -ExpectedMessage '*Failed to verify file*'
     }
 
+    It ' Decrypts normally when Verify is explicitly false' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeyPublic1 = $KeyPublic1 } {
+        $protected = Protect-PGP -FilePathPublic $KeyPublic -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Explicit false verify text'
+        $plain = Unprotect-PGP -FilePathPrivate $KeyPrivate -FilePathPublic $KeyPublic1 -Password 'ZielonaMila9!' -String $protected -Verify:$false -ErrorAction Stop
+        $plain | Should -Be 'Explicit false verify text'
+    }
+
     It ' Encrypt, sign, decrypt and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt')
         $protectedFile = [io.path]::Combine($KeysDirectory, 'decrypt-verify-input.txt.pgp')


### PR DESCRIPTION
## Summary
- upgrade PgpCore from 7.0.0 to 7.1.0
- restore Unprotect-PGP -Verify for signed-and-encrypted string and file decrypt flows
- stage verified file output through a temporary file before moving it into place after signature verification succeeds
- update README guidance and PowerShell coverage for verified decrypt success and wrong-public-key rejection

## Validation
- dotnet restore Sources\PSPGP.sln
- dotnet build Sources\PSPGP.sln --configuration Release --no-restore
- dotnet test Sources\PSPGP.Tests\PSPGP.Tests.csproj --configuration Release --framework net8.0 --no-build --verbosity normal
- dotnet build Sources\PSPGP.sln --configuration Debug --no-restore
- pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\PSPGP.Tests.ps1
- powershell.exe -NoLogo -NoProfile -ExecutionPolicy Bypass -File .\PSPGP.Tests.ps1
- git diff --check
