### PR TITLE
Bump PgpCore to 7.2.0

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -142,7 +142,7 @@ $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -
 Get-PGPInspect -String $Signature
 ```
 
-`Get-PGPInspect` works well for signed content and general armored metadata. Inspection of some encrypted payloads is still limited by upstream `PgpCore` behavior, and PSPGP reports that limitation clearly instead of surfacing a raw crash.
+`Get-PGPInspect` returns metadata for signed content, armored messages, and encrypted messages that can be inspected without decrypting the payload.
 
 ### Sign string
 

--- a/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
+++ b/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
@@ -47,4 +47,16 @@ public class KeyMaterialHelperTests {
         normalized.Message.Should().Contain("AEAD");
         normalized.InnerException.Should().BeSameAs(exception);
     }
+
+    [Fact]
+    public void Normalize_WithWrappedPacketType20Error_ShouldReturnAeadGuidance() {
+        var innerException = new IOException("unknown packet type encountered: 20");
+        var exception = new InvalidDataException("encrypted data was not readable", innerException);
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception);
+
+        normalized.Should().BeOfType<NotSupportedException>();
+        normalized.Message.Should().Contain("AEAD");
+        normalized.InnerException.Should().BeSameAs(exception);
+    }
 }

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -58,7 +58,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
     private static System.Exception NormalizeInspectException(System.Exception exception) {
         if (exception is System.NullReferenceException) {
             return new System.NotSupportedException(
-                "PgpCore inspect currently fails for some encrypted messages. Signed content inspection works, but encrypted-message inspection is limited by the upstream library.",
+                "PgpCore inspect could not read this message. Signed, armored, and encrypted packet metadata may still be inspectable for other inputs.",
                 exception);
         }
 

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -1,5 +1,8 @@
+using System;
 using System.IO;
 using System.Management.Automation;
+using System.Text;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using PgpCore;
 using PgpCore.Models;
 
@@ -39,16 +42,18 @@ public class CmdletGetPGPInspect : PSCmdlet {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
                 foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
                     try {
-                        WriteObject(ToInfo(file, pgp.Inspect(new FileInfo(file))));
+                        FileInfo fileInfo = new(file);
+                        WriteObject(ToInfo(file, pgp.Inspect(fileInfo), TryGetIntegrityProtected(fileInfo)));
                     } catch (System.Exception ex) {
                         WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, file));
                     }
                 }
             } else if (ParameterSetName == "File") {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
-                WriteObject(ToInfo(resolvedFile, pgp.Inspect(new FileInfo(resolvedFile))));
+                FileInfo fileInfo = new(resolvedFile);
+                WriteObject(ToInfo(resolvedFile, pgp.Inspect(fileInfo), TryGetIntegrityProtected(fileInfo)));
             } else {
-                WriteObject(ToInfo(null, pgp.Inspect(String)));
+                WriteObject(ToInfo(null, pgp.Inspect(String), TryGetIntegrityProtected(String)));
             }
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
@@ -65,16 +70,61 @@ public class CmdletGetPGPInspect : PSCmdlet {
         return exception;
     }
 
-    private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result) {
+    private static bool? TryGetIntegrityProtected(FileInfo fileInfo) {
+        try {
+            using FileStream stream = fileInfo.OpenRead();
+            return TryGetIntegrityProtected(stream);
+        } catch {
+            return null;
+        }
+    }
+
+    private static bool? TryGetIntegrityProtected(string value) {
+        try {
+            using var stream = new MemoryStream(Encoding.UTF8.GetBytes(value));
+            return TryGetIntegrityProtected(stream);
+        } catch {
+            return null;
+        }
+    }
+
+    private static bool? TryGetIntegrityProtected(Stream stream) {
+        try {
+            using Stream decoderStream = PgpUtilities.GetDecoderStream(stream);
+            var factory = new PgpObjectFactory(decoderStream);
+            object pgpObject;
+            while ((pgpObject = factory.NextPgpObject()) != null) {
+                if (pgpObject is PgpEncryptedDataList encryptedDataList) {
+                    foreach (PgpEncryptedData encryptedData in encryptedDataList.GetEncryptedDataObjects()) {
+                        return encryptedData.IsIntegrityProtected();
+                    }
+                }
+            }
+        } catch {
+            return null;
+        }
+
+        return null;
+    }
+
+    private static string GetHeaderValue(System.Collections.Generic.Dictionary<string, string> messageHeaders, string key) {
+        if (messageHeaders != null && messageHeaders.TryGetValue(key, out string value)) {
+            return value;
+        }
+
+        return null;
+    }
+
+    private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result, bool? integrityProtected) {
         return new PGPInspectInfo {
             SourcePath = sourcePath,
             IsArmored = result.IsArmored,
             MessageHeaders = result.MessageHeaders,
-            Version = result.Version,
-            Comment = result.Comment,
+            Version = GetHeaderValue(result.MessageHeaders, "Version"),
+            Comment = GetHeaderValue(result.MessageHeaders, "Comment"),
             IsCompressed = result.IsCompressed,
             IsEncrypted = result.IsEncrypted,
-            IsIntegrityProtected = result.IsIntegrityProtected,
+            IsIntegrityProtected = result.IsIntegrityProtected || integrityProtected == true,
             IsSigned = result.IsSigned,
             SymmetricKeyAlgorithm = result.SymmetricKeyAlgorithm,
             FileName = result.FileName,

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-        <PackageReference Include="PgpCore" Version="7.1.0" />
+        <PackageReference Include="PgpCore" Version="7.2.0" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Sources/PSPGP/PgpExceptionHelper.cs
+++ b/Sources/PSPGP/PgpExceptionHelper.cs
@@ -7,7 +7,7 @@ internal static class PgpExceptionHelper {
     internal static Exception Normalize(Exception exception, string keyPath = null) {
         string message = exception?.Message ?? string.Empty;
 
-        if (message.IndexOf("unknown packet type encountered: 20", StringComparison.OrdinalIgnoreCase) >= 0) {
+        if (ContainsMessage(exception, "unknown packet type encountered: 20")) {
             return new NotSupportedException(
                 "The encrypted content appears to use OpenPGP AEAD (packet type 20), which the underlying PgpCore/BouncyCastle stack cannot decrypt yet. Re-encrypt the file without AEAD, or remove the AEAD preference from the key before creating new encrypted content.",
                 exception);
@@ -23,5 +23,15 @@ internal static class PgpExceptionHelper {
         }
 
         return exception;
+    }
+
+    private static bool ContainsMessage(Exception exception, string value) {
+        for (Exception current = exception; current != null; current = current.InnerException) {
+            if ((current.Message ?? string.Empty).IndexOf(value, StringComparison.OrdinalIgnoreCase) >= 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -133,7 +133,7 @@
         $inspection.IsArmored | Should -Be $true
     }
 
-    It ' Inspect folder continues when one file cannot be inspected' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+    It ' Inspect folder returns signed and encrypted message metadata' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $inspectFolder = [io.path]::Combine($KeysDirectory, 'inspect-folder')
         $sourceFile = [io.path]::Combine($KeysDirectory, 'inspect-input.txt')
         $signedFile = [io.path]::Combine($inspectFolder, 'signed.asc')
@@ -146,11 +146,16 @@
         $inspectErrors = @()
         $results = Get-PGPInspect -FolderPath $inspectFolder -ErrorAction Continue -ErrorVariable +inspectErrors
 
-        $results.Count | Should -Be 1
-        [IO.Path]::GetFullPath($results[0].SourcePath) | Should -Be ([IO.Path]::GetFullPath($signedFile))
-        $results[0].IsSigned | Should -Be $true
-        $inspectErrors.Count | Should -Be 1
-        $inspectErrors[0].Exception.Message | Should -Match 'Signed content inspection works'
+        $results.Count | Should -Be 2
+
+        $signedResult = $results | Where-Object { [IO.Path]::GetFullPath($_.SourcePath) -eq [IO.Path]::GetFullPath($signedFile) }
+        $encryptedResult = $results | Where-Object { [IO.Path]::GetFullPath($_.SourcePath) -eq [IO.Path]::GetFullPath($encryptedFile) }
+
+        $signedResult.IsSigned | Should -Be $true
+        $signedResult.IsEncrypted | Should -Be $false
+        $encryptedResult.IsEncrypted | Should -Be $true
+        $encryptedResult.IsSigned | Should -Be $false
+        $inspectErrors.Count | Should -Be 0
     }
 
     It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -158,6 +158,29 @@
         $inspectErrors.Count | Should -Be 0
     }
 
+    It ' Inspect unarmored encrypted file returns encrypted metadata' -TestCases @{ KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'inspect-unarmored-input.txt')
+        $encryptedFile = [io.path]::Combine($KeysDirectory, 'inspect-unarmored.pgp')
+        Set-Content -Path $sourceFile -Value 'Inspect unarmored content' -NoNewline
+        Protect-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -OutFilePath $encryptedFile -Armor:$false -ErrorAction Stop
+
+        $inspection = Get-PGPInspect -FilePath $encryptedFile -ErrorAction Stop
+
+        $inspection.IsArmored | Should -Be $false
+        $inspection.IsEncrypted | Should -Be $true
+        $inspection.IsIntegrityProtected | Should -Be $true
+        $inspection.Version | Should -BeNullOrEmpty
+        $inspection.Comment | Should -BeNullOrEmpty
+    }
+
+    It ' Inspect symmetric encrypted string reports integrity protection' {
+        $protected = Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'Symmetric inspect text' -ErrorAction Stop
+        $inspection = Get-PGPInspect -String $protected -ErrorAction Stop
+
+        $inspection.IsEncrypted | Should -Be $true
+        $inspection.IsIntegrityProtected | Should -Be $true
+    }
+
     It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {
         $protected = Protect-PGP -FilePathPublic $KeyPublic -String 'Encrypted but unsigned'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $protected -ThrowIfEncrypted


### PR DESCRIPTION
## Summary
- Bump `PgpCore` from `7.1.0` to `7.2.0`.
- Update `Get-PGPInspect` messaging and docs for the improved encrypted-message metadata inspection behavior.
- Adjust the PowerShell contract test to expect signed and encrypted metadata results.

## Validation
- `dotnet build Sources\PSPGP.sln -c Release`
- `dotnet test Sources\PSPGP.sln -c Release`
- `dotnet build Sources\PSPGP.sln -c Debug`
- `pwsh -NoProfile -File .\PSPGP.Tests.ps1`
- `powershell -NoProfile -File .\PSPGP.Tests.ps1`
