### PR TITLE
Expose additional PgpCore capabilities

### DIFF
--- a/Examples/Example-DetachedSignature.ps1
+++ b/Examples/Example-DetachedSignature.ps1
@@ -1,0 +1,10 @@
+Import-Module (Join-Path $PSScriptRoot '..\PSPGP.psd1') -Force
+
+$Message = 'This text is signed separately from its detached signature'
+$Signature = Protect-PGP -SignOnly -Detached -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String $Message
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $Message -Signature $Signature
+
+$SourceFile = Join-Path $PSScriptRoot 'Test\Test1.txt'
+$SignatureFile = Join-Path $PSScriptRoot 'Test\Test1.txt.sig'
+Protect-PGP -SignOnly -Detached -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -FilePath $SourceFile -OutFilePath $SignatureFile
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $SourceFile -SignaturePath $SignatureFile

--- a/README.MD
+++ b/README.MD
@@ -47,9 +47,9 @@ Current capabilities:
 
 - Encrypt and decrypt files, folders, and strings with public/private keys
 - Encrypt and decrypt strings, files, and folders symmetrically with a passphrase
-- Create detached signatures and verify them with one or more public keys
-- Create clear-signed content and verify it
-- Inspect signed and armored message metadata with `Get-PGPInspect`
+- Create signed, detached-signature, and clear-signed content and verify it with one or more public keys
+- Write verified clear content from signed files to an output path
+- Inspect signed, encrypted, and armored message metadata with `Get-PGPInspect`, including encrypted recipient key IDs when available
 - Download public keys from a key server and inspect local key material
 - Generate new key pairs and optionally upload the public key
 
@@ -85,6 +85,8 @@ On Windows PowerShell 5.1, the module requires **.NET Framework 4.7.2** or newer
 
 ```powershell
 New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
+
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\ExpiringPublic.asc -FilePathPrivate $PSScriptRoot\Keys\ExpiringPrivate.asc -UserName 'user@example.com' -Password 'secret' -Strength 4096 -Certainty 8 -KeyExpirationInSeconds 31536000 -PreferredHashAlgorithm Sha256,Sha512 -PreferredSymmetricKeyAlgorithm Aes256
 ```
 
 ### Encrypt Folder
@@ -125,7 +127,18 @@ Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $ProtectedString
 $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Signed text'
 
 # Verify using one or more public keys
-Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc,$PSScriptRoot\Keys\PublicPGP2.asc -String $Signature
+$Result = Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc,$PSScriptRoot\Keys\PublicPGP2.asc -String $Signature
+$Result.ClearText
+```
+
+### Detached signatures
+
+```powershell
+$Signature = Protect-PGP -SignOnly -Detached -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -String 'Detached signed text'
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String 'Detached signed text' -Signature $Signature
+
+Protect-PGP -SignOnly -Detached -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'ZielonaMila9!' -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Test\Test1.txt.sig
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -SignaturePath $PSScriptRoot\Test\Test1.txt.sig
 ```
 
 ### Clear sign and verify clear-signed content
@@ -142,7 +155,7 @@ $Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -
 Get-PGPInspect -String $Signature
 ```
 
-`Get-PGPInspect` returns metadata for signed content, armored messages, and encrypted messages that can be inspected without decrypting the payload.
+`Get-PGPInspect` returns metadata for signed content, armored messages, and encrypted messages that can be inspected without decrypting the payload. For encrypted content it also reports recipient key IDs when the packet exposes them.
 
 ### Sign string
 
@@ -183,6 +196,7 @@ See the `Examples` folder for runnable scripts:
 - `Examples\Example-DecryptFile.ps1`
 - `Examples\Example-SignString.ps1`
 - `Examples\Example-VerifySignature.ps1`
+- `Examples\Example-DetachedSignature.ps1`
 - `Examples\Example-ClearSignString.ps1`
 - `Examples\Example-SymmetricString.ps1`
 - `Examples\Example-InspectSignedString.ps1`

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Management.Automation;
 using System.Text;
 using Org.BouncyCastle.Bcpg.OpenPgp;
@@ -43,7 +45,11 @@ public class CmdletGetPGPInspect : PSCmdlet {
                 foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
                     try {
                         FileInfo fileInfo = new(file);
-                        WriteObject(ToInfo(file, pgp.Inspect(fileInfo), TryGetIntegrityProtected(fileInfo)));
+                        WriteObject(ToInfo(
+                            file,
+                            pgp.Inspect(fileInfo),
+                            GetRecipientKeyIds(() => pgp.GetFileRecipients(fileInfo)),
+                            TryGetIntegrityProtected(fileInfo)));
                     } catch (System.Exception ex) {
                         WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, file));
                     }
@@ -51,9 +57,17 @@ public class CmdletGetPGPInspect : PSCmdlet {
             } else if (ParameterSetName == "File") {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
                 FileInfo fileInfo = new(resolvedFile);
-                WriteObject(ToInfo(resolvedFile, pgp.Inspect(fileInfo), TryGetIntegrityProtected(fileInfo)));
+                WriteObject(ToInfo(
+                    resolvedFile,
+                    pgp.Inspect(fileInfo),
+                    GetRecipientKeyIds(() => pgp.GetFileRecipients(fileInfo)),
+                    TryGetIntegrityProtected(fileInfo)));
             } else {
-                WriteObject(ToInfo(null, pgp.Inspect(String), TryGetIntegrityProtected(String)));
+                WriteObject(ToInfo(
+                    null,
+                    pgp.Inspect(String),
+                    GetRecipientKeyIds(() => pgp.GetArmoredStringRecipients(String)),
+                    TryGetIntegrityProtected(String)));
             }
         } catch (System.Exception ex) {
             WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
@@ -68,6 +82,16 @@ public class CmdletGetPGPInspect : PSCmdlet {
         }
 
         return exception;
+    }
+
+    private static string[] GetRecipientKeyIds(Func<IEnumerable<long>> getRecipients) {
+        try {
+            return getRecipients()
+                .Select(id => $"0x{unchecked((ulong)id):X16}")
+                .ToArray();
+        } catch {
+            return Array.Empty<string>();
+        }
     }
 
     private static bool? TryGetIntegrityProtected(FileInfo fileInfo) {
@@ -107,7 +131,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
         return null;
     }
 
-    private static string GetHeaderValue(System.Collections.Generic.Dictionary<string, string> messageHeaders, string key) {
+    private static string GetHeaderValue(Dictionary<string, string> messageHeaders, string key) {
         if (messageHeaders != null && messageHeaders.TryGetValue(key, out string value)) {
             return value;
         }
@@ -115,7 +139,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
         return null;
     }
 
-    private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result, bool? integrityProtected) {
+    private static PGPInspectInfo ToInfo(string sourcePath, PgpInspectResult result, string[] recipientKeyIds, bool? integrityProtected) {
         return new PGPInspectInfo {
             SourcePath = sourcePath,
             IsArmored = result.IsArmored,
@@ -124,6 +148,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
             Comment = GetHeaderValue(result.MessageHeaders, "Comment"),
             IsCompressed = result.IsCompressed,
             IsEncrypted = result.IsEncrypted,
+            RecipientKeyIds = recipientKeyIds,
             IsIntegrityProtected = result.IsIntegrityProtected || integrityProtected == true,
             IsSigned = result.IsSigned,
             SymmetricKeyAlgorithm = result.SymmetricKeyAlgorithm,

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -68,14 +68,39 @@ public class CmdletNewPGPKey : PSCmdlet {
     [Parameter(ParameterSetName = "StrengthCredential")]
     public SwitchParameter EmitVersion { get; set; }
 
+    /// <summary>Controls whether generated key files are ASCII armored.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public bool Armor { get; set; } = true;
+
+    /// <summary>Key expiration in seconds. Use zero for no expiration.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public long KeyExpirationInSeconds { get; set; }
+
+    /// <summary>Signature expiration in seconds. Use zero for no expiration.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public long SignatureExpirationInSeconds { get; set; }
+
     /// <summary>Optional hash algorithm used when generating keys.</summary>
     [Parameter]
     [Alias("HashAlgorithmTag")]
     public HashAlgorithmTag? HashAlgorithm { get; set; }
 
+    /// <summary>Preferred hash algorithms advertised by the generated key.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public HashAlgorithmTag[] PreferredHashAlgorithm { get; set; }
+
     /// <summary>Optional compression algorithm used when generating keys.</summary>
     [Parameter]
     public CompressionAlgorithmTag? CompressionAlgorithm { get; set; }
+
+    /// <summary>Preferred compression algorithms advertised by the generated key.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public CompressionAlgorithmTag[] PreferredCompressionAlgorithm { get; set; }
 
     /// <summary>Defines the file type stored within the PGP package.</summary>
     [Parameter]
@@ -92,6 +117,11 @@ public class CmdletNewPGPKey : PSCmdlet {
     /// <summary>Symmetric key algorithm used for encryption.</summary>
     [Parameter]
     public SymmetricKeyAlgorithmTag? SymmetricKeyAlgorithm { get; set; }
+
+    /// <summary>Preferred symmetric algorithms advertised by the generated key.</summary>
+    [Parameter(ParameterSetName = "Strength")]
+    [Parameter(ParameterSetName = "StrengthCredential")]
+    public SymmetricKeyAlgorithmTag[] PreferredSymmetricKeyAlgorithm { get; set; }
 
     /// <summary>
     /// Generates a new key pair based on the provided
@@ -113,7 +143,20 @@ public class CmdletNewPGPKey : PSCmdlet {
             }
 
             if (ParameterSetName.StartsWith("Strength")) {
-                pgp.GenerateKey(new FileInfo(resolvedPublic), new FileInfo(resolvedPrivate), user, pass, Strength, Certainty, EmitVersion.IsPresent);
+                pgp.GenerateKey(
+                    new FileInfo(resolvedPublic),
+                    new FileInfo(resolvedPrivate),
+                    user,
+                    pass,
+                    Strength,
+                    Certainty,
+                    Armor,
+                    EmitVersion.IsPresent,
+                    KeyExpirationInSeconds,
+                    SignatureExpirationInSeconds,
+                    PreferredCompressionAlgorithm ?? ToArray(CompressionAlgorithm),
+                    PreferredHashAlgorithm ?? ToArray(HashAlgorithm),
+                    PreferredSymmetricKeyAlgorithm ?? ToArray(SymmetricKeyAlgorithm));
             } else {
                 pgp.GenerateKey(new FileInfo(resolvedPublic), new FileInfo(resolvedPrivate), user, pass);
             }
@@ -125,5 +168,9 @@ public class CmdletNewPGPKey : PSCmdlet {
         } catch (Exception ex) {
             WriteError(new ErrorRecord(ex, "NewPGPKeyFailed", ErrorCategory.NotSpecified, null));
         }
+    }
+
+    private static T[] ToArray<T>(T? value) where T : struct {
+        return value.HasValue ? new[] { value.Value } : null;
     }
 }

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -142,6 +142,10 @@ public class CmdletNewPGPKey : PSCmdlet {
                 pass = Credential.GetNetworkCredential().Password;
             }
 
+            if (!Armor && !string.IsNullOrEmpty(UploadKeyServer)) {
+                throw new InvalidOperationException("New-PGPKey requires armored public key output when UploadKeyServer is used.");
+            }
+
             if (ParameterSetName.StartsWith("Strength")) {
                 pgp.GenerateKey(
                     new FileInfo(resolvedPublic),

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -11,8 +11,8 @@ namespace PSPGP;
 /// <summary>
 /// <para>
 /// Encrypts or signs files, folders or strings using one or more public keys.
-/// Use <c>-SignOnly</c> or the <c>Sign*</c> parameter sets to create detached
-/// signatures without encryption.
+/// Use <c>-SignOnly</c> or the <c>Sign*</c> parameter sets to create signatures
+/// without encryption. Add <c>-Detached</c> to create a separate detached signature.
 /// </para>
 /// </summary>
 /// <example>
@@ -170,6 +170,10 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter]
     public SwitchParameter OldFormat { get; set; }
 
+    /// <summary>Adds the PGP version header to generated armored content.</summary>
+    [Parameter]
+    public SwitchParameter AddVersionHeader { get; set; }
+
     /// <summary>
     /// When specified, only a signature is produced instead of encrypting
     /// the input. This parameter is automatically implied when using the
@@ -179,6 +183,12 @@ public class CmdletProtectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "SignFile")]
     [Parameter(Mandatory = true, ParameterSetName = "SignString")]
     public SwitchParameter SignOnly { get; set; }
+
+    /// <summary>Creates a detached signature over the original input.</summary>
+    [Parameter(ParameterSetName = "SignFolder")]
+    [Parameter(ParameterSetName = "SignFile")]
+    [Parameter(ParameterSetName = "SignString")]
+    public SwitchParameter Detached { get; set; }
 
     /// <summary>
     /// Creates a clear-signed message that remains human readable.
@@ -245,6 +255,7 @@ public class CmdletProtectPGP : PSCmdlet {
             var pgp = new PGP(encryptionKeys);
 
             PGPConfigurator.Configure(pgp, HashAlgorithm, CompressionAlgorithm, FileType, PgpSignatureType, PublicKeyAlgorithm, SymmetricKeyAlgorithm);
+            if (AddVersionHeader.IsPresent) pgp.AddVersionHeader = true;
 
             if (ParameterSetName == "Folder" || ParameterSetName == "SignFolder" || ParameterSetName == "ClearSignFolder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
@@ -257,7 +268,11 @@ public class CmdletProtectPGP : PSCmdlet {
                     if (clearSignMode) {
                         pgp.ClearSignFile(new FileInfo(file), new FileInfo(outputFile), headers);
                     } else if (signOnlyMode) {
-                        pgp.SignFile(new FileInfo(file), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
+                        if (Detached.IsPresent) {
+                            pgp.SignDetached(new FileInfo(file), new FileInfo(outputFile), Armor, headers);
+                        } else {
+                            pgp.SignFile(new FileInfo(file), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
+                        }
                     } else if (SignKey != null) {
                         pgp.EncryptFileAndSign(new FileInfo(file), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                     } else {
@@ -272,7 +287,11 @@ public class CmdletProtectPGP : PSCmdlet {
                 if (clearSignMode) {
                     pgp.ClearSignFile(new FileInfo(resolvedFile), new FileInfo(outputFile), headers);
                 } else if (signOnlyMode) {
-                    pgp.SignFile(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
+                    if (Detached.IsPresent) {
+                        pgp.SignDetached(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, headers);
+                    } else {
+                        pgp.SignFile(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, LiteralFileName, headers, OldFormat.IsPresent);
+                    }
                 } else if (SignKey != null) {
                     pgp.EncryptFileAndSign(new FileInfo(resolvedFile), new FileInfo(outputFile), Armor, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);
                 } else {
@@ -282,7 +301,9 @@ public class CmdletProtectPGP : PSCmdlet {
                 string result = clearSignMode
                     ? pgp.ClearSignArmoredString(String, headers)
                     : signOnlyMode
-                    ? pgp.SignArmoredString(String, LiteralFileName, headers, OldFormat.IsPresent)
+                    ? Detached.IsPresent
+                        ? pgp.SignDetached(String, headers)
+                        : pgp.SignArmoredString(String, LiteralFileName, headers, OldFormat.IsPresent)
                     : SignKey != null
                         ? pgp.EncryptArmoredStringAndSign(String, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent)
                         : pgp.EncryptArmoredString(String, WithIntegrityCheck, LiteralFileName, headers, OldFormat.IsPresent);

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -133,6 +133,7 @@ public class CmdletTestPGP : PSCmdlet {
                     ErrorCategory.InvalidArgument,
                     resolved,
                     $"Public key doesn't exist {resolved}");
+                publicKeys.Clear();
                 return publicKeys;
             }
             DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
@@ -163,7 +164,7 @@ public class CmdletTestPGP : PSCmdlet {
                             : pgp.VerifyFile(new FileInfo(filePath), ThrowIfEncrypted.IsPresent);
                 if (status) {
                     signer = key;
-                    verifiedOutput = outputPath;
+                    verifiedOutput = string.IsNullOrEmpty(signaturePath) ? outputPath : null;
                     break;
                 }
             } catch (Exception ex) {

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -100,7 +100,7 @@ public class CmdletTestPGP : PSCmdlet {
 
                 foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
                     string outputPath = !string.IsNullOrEmpty(resolvedOutputFolder)
-                        ? Path.Combine(resolvedOutputFolder, GetVerifiedOutputFileName(file))
+                        ? GetVerifiedOutputPath(resolvedFolder, resolvedOutputFolder, file)
                         : null;
                     WriteObject(VerifyFileWithAnyKey(file, null, outputPath, publicKeys));
                 }
@@ -227,7 +227,7 @@ public class CmdletTestPGP : PSCmdlet {
             EnsureDirectoryForFile(temporaryOutput);
             bool verified = ClearSigned.IsPresent
                 ? pgp.VerifyClear(new FileInfo(inputFile), new FileInfo(temporaryOutput))
-                : pgp.Verify(new FileInfo(inputFile), new FileInfo(temporaryOutput), ThrowIfEncrypted.IsPresent);
+                : pgp.Verify(new FileInfo(inputFile), new FileInfo(temporaryOutput), true);
             if (!verified) {
                 return false;
             }
@@ -245,6 +245,17 @@ public class CmdletTestPGP : PSCmdlet {
         }
     }
 
+    private static string GetVerifiedOutputPath(string inputFolder, string outputFolder, string inputFile) {
+        string relativeInput = GetRelativePath(inputFolder, inputFile);
+        string relativeDirectory = Path.GetDirectoryName(relativeInput);
+        string outputFileName = GetVerifiedOutputFileName(relativeInput);
+        string relativeOutput = string.IsNullOrEmpty(relativeDirectory)
+            ? outputFileName
+            : Path.Combine(relativeDirectory, outputFileName);
+
+        return Path.Combine(outputFolder, relativeOutput);
+    }
+
     private static string GetVerifiedOutputFileName(string inputFile) {
         string fileName = Path.GetFileName(inputFile);
         foreach (string extension in new[] { ".asc", ".sig", ".pgp", ".gpg" }) {
@@ -254,6 +265,30 @@ public class CmdletTestPGP : PSCmdlet {
         }
 
         return fileName;
+    }
+
+    private static string GetRelativePath(string inputFolder, string inputFile) {
+        string root = EnsureTrailingDirectorySeparator(Path.GetFullPath(inputFolder));
+        string file = Path.GetFullPath(inputFile);
+        var rootUri = new Uri(root);
+        var fileUri = new Uri(file);
+        if (!string.Equals(rootUri.Scheme, fileUri.Scheme, StringComparison.OrdinalIgnoreCase)) {
+            return Path.GetFileName(file);
+        }
+
+        string relative = Uri.UnescapeDataString(rootUri.MakeRelativeUri(fileUri).ToString());
+        return string.Equals(fileUri.Scheme, Uri.UriSchemeFile, StringComparison.OrdinalIgnoreCase)
+            ? relative.Replace('/', Path.DirectorySeparatorChar)
+            : relative;
+    }
+
+    private static string EnsureTrailingDirectorySeparator(string path) {
+        if (path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.Ordinal)
+            || path.EndsWith(Path.AltDirectorySeparatorChar.ToString(), StringComparison.Ordinal)) {
+            return path;
+        }
+
+        return path + Path.DirectorySeparatorChar;
     }
 
     private static void EnsureDirectoryForFile(string filePath) {

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -20,6 +20,11 @@ namespace PSPGP;
 /// </example>
 /// <example>
 /// <code>
+/// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -SignaturePath $PSScriptRoot\Test\Test1.txt.sig
+/// </code>
+/// </example>
+/// <example>
+/// <code>
 /// Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned
 /// </code>
 /// </example>
@@ -41,7 +46,7 @@ public class CmdletTestPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "Folder")]
     public string FolderPath { get; set; }
 
-    /// <summary>Destination folder for verification reports.</summary>
+    /// <summary>Destination folder for verified clear content.</summary>
     [Parameter(ParameterSetName = "Folder")]
     public string OutputFolderPath { get; set; }
 
@@ -49,19 +54,27 @@ public class CmdletTestPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "File")]
     public string FilePath { get; set; }
 
-    /// <summary>Output path for verification result.</summary>
+    /// <summary>Detached signature file for the input file.</summary>
+    [Parameter(ParameterSetName = "File")]
+    public string SignaturePath { get; set; }
+
+    /// <summary>Output path for verified clear content.</summary>
     [Parameter(ParameterSetName = "File")]
     public string OutFilePath { get; set; }
 
-    /// <summary>Encrypted text to verify.</summary>
+    /// <summary>Signed text or original text when Signature is provided.</summary>
     [Parameter(Mandatory = true, ParameterSetName = "String")]
     public string String { get; set; }
+
+    /// <summary>Detached signature for the string input.</summary>
+    [Parameter(ParameterSetName = "String")]
+    public string Signature { get; set; }
 
     /// <summary>Throws when encrypted content is passed to verify methods.</summary>
     [Parameter]
     public SwitchParameter ThrowIfEncrypted { get; set; }
 
-    /// <summary>Verifies clear-signed content instead of detached/regular signatures.</summary>
+    /// <summary>Verifies clear-signed content instead of regular signed content.</summary>
     [Parameter]
     public SwitchParameter ClearSigned { get; set; }
 
@@ -71,111 +84,193 @@ public class CmdletTestPGP : PSCmdlet {
     /// </summary>
     protected override void ProcessRecord() {
         try {
-            var publicKeys = new List<string>();
-            foreach (var path in FilePathPublic) {
-                var resolved = PathResolver.Resolve(this, path);
-                if (!File.Exists(resolved)) {
-                    ErrorActionHelper.WriteErrorOrWarning(
-                        this,
-                        new FileNotFoundException($"Public key doesn't exist {resolved}"),
-                        "PublicKeyNotFound",
-                        ErrorCategory.InvalidArgument,
-                        resolved,
-                        $"Public key doesn't exist {resolved}");
-                    return;
-                }
-                DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
-                KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
-                publicKeys.Add(resolved);
+            List<string> publicKeys = ResolvePublicKeys();
+            if (publicKeys.Count == 0) {
+                return;
             }
 
             if (ParameterSetName == "Folder") {
                 string resolvedFolder = PathResolver.Resolve(this, FolderPath);
-                foreach (var file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
-                    bool status = false;
-                    string error = string.Empty;
-                    string signer = null;
-                    foreach (var key in publicKeys) {
-                        try {
-                            using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
-                            var encryptionKeys = new EncryptionKeys(publicKeyStream);
-                            var pgp = new PGP(encryptionKeys);
-                            status = ClearSigned.IsPresent
-                                ? pgp.VerifyClearFile(new FileInfo(file))
-                                : pgp.VerifyFile(new FileInfo(file), ThrowIfEncrypted.IsPresent);
-                            if (status) {
-                                signer = key;
-                                break;
-                            }
-                        } catch (Exception ex) {
-                            error = PgpExceptionHelper.Normalize(ex, key).Message;
-                        }
-                    }
-                    var result = new VerificationResult {
-                        FilePath = file,
-                        Status = status,
-                        Error = status ? null : error,
-                        Signer = signer
-                    };
-                    WriteObject(result);
+                string resolvedOutputFolder = !string.IsNullOrEmpty(OutputFolderPath)
+                    ? PathResolver.Resolve(this, OutputFolderPath)
+                    : null;
+                if (!string.IsNullOrEmpty(resolvedOutputFolder)) {
+                    Directory.CreateDirectory(resolvedOutputFolder);
+                }
+
+                foreach (string file in Directory.GetFiles(resolvedFolder, "*", SearchOption.AllDirectories)) {
+                    string outputPath = !string.IsNullOrEmpty(resolvedOutputFolder)
+                        ? Path.Combine(resolvedOutputFolder, GetVerifiedOutputFileName(file))
+                        : null;
+                    WriteObject(VerifyFileWithAnyKey(file, null, outputPath, publicKeys));
                 }
             } else if (ParameterSetName == "File") {
                 string resolvedFile = PathResolver.Resolve(this, FilePath);
-                bool status = false;
-                string error = string.Empty;
-                string signer = null;
-                foreach (var key in publicKeys) {
-                    try {
-                        using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
-                        var encryptionKeys = new EncryptionKeys(publicKeyStream);
-                        var pgp = new PGP(encryptionKeys);
-                        status = ClearSigned.IsPresent
-                            ? pgp.VerifyClearFile(new FileInfo(resolvedFile))
-                            : pgp.VerifyFile(new FileInfo(resolvedFile), ThrowIfEncrypted.IsPresent);
-                        if (status) {
-                            signer = key;
-                            break;
-                        }
-                    } catch (Exception ex) {
-                        error = PgpExceptionHelper.Normalize(ex, key).Message;
-                    }
-                }
-                var result = new VerificationResult {
-                    FilePath = resolvedFile,
-                    Status = status,
-                    Error = status ? null : error,
-                    Signer = signer
-                };
-                WriteObject(result);
+                string resolvedSignature = !string.IsNullOrEmpty(SignaturePath)
+                    ? PathResolver.Resolve(this, SignaturePath)
+                    : null;
+                string resolvedOutput = !string.IsNullOrEmpty(OutFilePath)
+                    ? PathResolver.Resolve(this, OutFilePath)
+                    : null;
+                WriteObject(VerifyFileWithAnyKey(resolvedFile, resolvedSignature, resolvedOutput, publicKeys));
             } else if (ParameterSetName == "String") {
-                bool status = false;
-                string error = string.Empty;
-                string signer = null;
-                foreach (var key in publicKeys) {
-                    try {
-                        using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
-                        var encryptionKeys = new EncryptionKeys(publicKeyStream);
-                        var pgp = new PGP(encryptionKeys);
-                        status = ClearSigned.IsPresent
-                            ? pgp.VerifyClearArmoredString(String)
-                            : pgp.VerifyArmoredString(String, ThrowIfEncrypted.IsPresent);
-                        if (status) {
-                            signer = key;
-                            break;
-                        }
-                    } catch (Exception ex) {
-                        error = PgpExceptionHelper.Normalize(ex, key).Message;
-                    }
-                }
-                var result = new VerificationResult {
-                    Status = status,
-                    Error = status ? null : error,
-                    Signer = signer
-                };
-                WriteObject(result);
+                WriteObject(VerifyStringWithAnyKey(String, Signature, publicKeys));
             }
         } catch (Exception ex) {
             WriteError(new ErrorRecord(ex, "TestPGPFailed", ErrorCategory.NotSpecified, null));
         }
+    }
+
+    private List<string> ResolvePublicKeys() {
+        var publicKeys = new List<string>();
+        foreach (string path in FilePathPublic) {
+            string resolved = PathResolver.Resolve(this, path);
+            if (!File.Exists(resolved)) {
+                ErrorActionHelper.WriteErrorOrWarning(
+                    this,
+                    new FileNotFoundException($"Public key doesn't exist {resolved}"),
+                    "PublicKeyNotFound",
+                    ErrorCategory.InvalidArgument,
+                    resolved,
+                    $"Public key doesn't exist {resolved}");
+                return publicKeys;
+            }
+            DateTime? expiration = KeyExpirationHelper.GetExpiration(resolved);
+            KeyExpirationHelper.WarnIfExpired(this, resolved, expiration);
+            publicKeys.Add(resolved);
+        }
+
+        return publicKeys;
+    }
+
+    private VerificationResult VerifyFileWithAnyKey(string filePath, string signaturePath, string outputPath, List<string> publicKeys) {
+        bool status = false;
+        string error = string.Empty;
+        string signer = null;
+        string verifiedOutput = null;
+
+        foreach (string key in publicKeys) {
+            try {
+                using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
+                var encryptionKeys = new EncryptionKeys(publicKeyStream);
+                var pgp = new PGP(encryptionKeys);
+                status = !string.IsNullOrEmpty(signaturePath)
+                    ? pgp.VerifyDetached(new FileInfo(filePath), new FileInfo(signaturePath))
+                    : !string.IsNullOrEmpty(outputPath)
+                        ? VerifyFileToOutput(pgp, filePath, outputPath)
+                        : ClearSigned.IsPresent
+                            ? pgp.VerifyClearFile(new FileInfo(filePath))
+                            : pgp.VerifyFile(new FileInfo(filePath), ThrowIfEncrypted.IsPresent);
+                if (status) {
+                    signer = key;
+                    verifiedOutput = outputPath;
+                    break;
+                }
+            } catch (Exception ex) {
+                error = PgpExceptionHelper.Normalize(ex, key).Message;
+            }
+        }
+
+        return new VerificationResult {
+            FilePath = filePath,
+            Status = status,
+            Error = status ? null : error,
+            Signer = signer,
+            OutputPath = status ? verifiedOutput : null
+        };
+    }
+
+    private VerificationResult VerifyStringWithAnyKey(string input, string signature, List<string> publicKeys) {
+        bool status = false;
+        string clearText = null;
+        string error = string.Empty;
+        string signer = null;
+
+        foreach (string key in publicKeys) {
+            try {
+                using var publicKeyStream = KeyMaterialHelper.OpenRead(key);
+                var encryptionKeys = new EncryptionKeys(publicKeyStream);
+                var pgp = new PGP(encryptionKeys);
+                if (!string.IsNullOrEmpty(signature)) {
+                    status = pgp.VerifyDetached(input, signature);
+                } else if (ClearSigned.IsPresent) {
+                    PgpCore.Models.VerificationResult result = pgp.VerifyAndReadClearArmoredString(input);
+                    status = result.IsVerified;
+                    clearText = result.ClearText;
+                } else {
+                    PgpCore.Models.VerificationResult result = pgp.VerifyAndReadSignedArmoredString(input, ThrowIfEncrypted.IsPresent);
+                    status = result.IsVerified;
+                    clearText = result.ClearText;
+                }
+
+                if (status) {
+                    signer = key;
+                    break;
+                }
+            } catch (Exception ex) {
+                error = PgpExceptionHelper.Normalize(ex, key).Message;
+            }
+        }
+
+        return new VerificationResult {
+            Status = status,
+            Error = status ? null : error,
+            Signer = signer,
+            ClearText = status ? clearText : null
+        };
+    }
+
+    private bool VerifyFileToOutput(PGP pgp, string inputFile, string outputFile) {
+        string temporaryOutput = GetTemporaryOutputFile(outputFile);
+        try {
+            EnsureDirectoryForFile(temporaryOutput);
+            bool verified = ClearSigned.IsPresent
+                ? pgp.VerifyClear(new FileInfo(inputFile), new FileInfo(temporaryOutput))
+                : pgp.Verify(new FileInfo(inputFile), new FileInfo(temporaryOutput), ThrowIfEncrypted.IsPresent);
+            if (!verified) {
+                return false;
+            }
+
+            EnsureDirectoryForFile(outputFile);
+            if (File.Exists(outputFile)) {
+                File.Delete(outputFile);
+            }
+            File.Move(temporaryOutput, outputFile);
+            return true;
+        } finally {
+            if (File.Exists(temporaryOutput)) {
+                File.Delete(temporaryOutput);
+            }
+        }
+    }
+
+    private static string GetVerifiedOutputFileName(string inputFile) {
+        string fileName = Path.GetFileName(inputFile);
+        foreach (string extension in new[] { ".asc", ".sig", ".pgp", ".gpg" }) {
+            if (fileName.EndsWith(extension, StringComparison.OrdinalIgnoreCase)) {
+                return fileName.Substring(0, fileName.Length - extension.Length);
+            }
+        }
+
+        return fileName;
+    }
+
+    private static void EnsureDirectoryForFile(string filePath) {
+        string directory = Path.GetDirectoryName(filePath);
+        if (string.IsNullOrEmpty(directory)) {
+            directory = Directory.GetCurrentDirectory();
+        }
+
+        Directory.CreateDirectory(directory);
+    }
+
+    private static string GetTemporaryOutputFile(string outputFile) {
+        string directory = Path.GetDirectoryName(outputFile);
+        string fileName = Path.GetFileName(outputFile);
+        if (string.IsNullOrEmpty(directory)) {
+            directory = Directory.GetCurrentDirectory();
+        }
+
+        return Path.Combine(directory, $".{fileName}.{Guid.NewGuid():N}.tmp");
     }
 }

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -123,6 +123,10 @@ public class CmdletUnprotectPGP : PSCmdlet {
     [Parameter(Mandatory = true, ParameterSetName = "StringVerifyCredential")]
     public SwitchParameter Verify { get; set; }
 
+    /// <summary>Ignores modification-detection/integrity-check failures during decryption.</summary>
+    [Parameter]
+    public SwitchParameter IgnoreIntegrityCheckFailure { get; set; }
+
     /// <summary>
     /// Decrypts files or strings using the supplied private keys
     /// and writes the decrypted data to disk or the pipeline.
@@ -195,6 +199,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                             try {
                                 var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                                 var pgp = new PGP(encryptionKeys);
+                                ConfigureDecryption(pgp);
                                 pgp.DecryptFile(new FileInfo(file), new FileInfo(outputFile));
                                 decrypted = true;
                             } catch (Exception ex) {
@@ -208,6 +213,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                                     try {
                                         var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
                                         var pgp = new PGP(encryptionKeys);
+                                        ConfigureDecryption(pgp);
                                         if (verifyMode) {
                                             DecryptFileAndVerifyToOutput(pgp, file, outputFile);
                                         } else {
@@ -243,6 +249,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         try {
                             var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                             var pgp = new PGP(encryptionKeys);
+                            ConfigureDecryption(pgp);
                             pgp.DecryptFile(new FileInfo(resolvedFile), new FileInfo(outputFile));
                             decrypted = true;
                         } catch (Exception ex) {
@@ -256,6 +263,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                                 try {
                                     var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
                                     var pgp = new PGP(encryptionKeys);
+                                    ConfigureDecryption(pgp);
                                     if (verifyMode) {
                                         DecryptFileAndVerifyToOutput(pgp, resolvedFile, outputFile);
                                     } else {
@@ -288,6 +296,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         try {
                             var encryptionKeys = new EncryptionKeys(Encoding.UTF8.GetBytes(SymmetricPassphrase));
                             var pgp = new PGP(encryptionKeys);
+                            ConfigureDecryption(pgp);
                             result = pgp.DecryptArmoredString(String);
                             decrypted = true;
                         } catch (Exception ex) {
@@ -301,6 +310,7 @@ public class CmdletUnprotectPGP : PSCmdlet {
                                 try {
                                     var encryptionKeys = CreateEncryptionKeys(privateKeyStream, password, resolvedPublics, verifyMode, out publicKeyStreams);
                                     var pgp = new PGP(encryptionKeys);
+                                    ConfigureDecryption(pgp);
                                     result = verifyMode
                                         ? pgp.DecryptArmoredStringAndVerify(String)
                                         : pgp.DecryptArmoredString(String);
@@ -326,6 +336,12 @@ public class CmdletUnprotectPGP : PSCmdlet {
             }
         } catch (Exception ex) {
             WriteError(new ErrorRecord(ex, "UnprotectPGPFailed", ErrorCategory.NotSpecified, null));
+        }
+    }
+
+    private void ConfigureDecryption(PGP pgp) {
+        if (IgnoreIntegrityCheckFailure.IsPresent) {
+            pgp.IgnoreIntegrityCheckFailure = true;
         }
     }
 

--- a/Sources/PSPGP/PGPInspectInfo.cs
+++ b/Sources/PSPGP/PGPInspectInfo.cs
@@ -28,6 +28,9 @@ public class PGPInspectInfo {
     /// <summary>Indicates whether the message is encrypted.</summary>
     public bool IsEncrypted { get; set; }
 
+    /// <summary>Recipient key IDs found in encrypted content.</summary>
+    public string[] RecipientKeyIds { get; set; }
+
     /// <summary>Indicates whether the message is integrity protected.</summary>
     public bool IsIntegrityProtected { get; set; }
 

--- a/Sources/PSPGP/VerificationResult.cs
+++ b/Sources/PSPGP/VerificationResult.cs
@@ -15,4 +15,10 @@ public class VerificationResult {
 
     /// <summary>Public key used to verify the signature.</summary>
     public string Signer { get; set; }
+
+    /// <summary>Verified clear text when the verified input carries readable content.</summary>
+    public string ClearText { get; set; }
+
+    /// <summary>File written after successful verification when an output path was requested.</summary>
+    public string OutputPath { get; set; }
 }

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -59,12 +59,20 @@
         $signed = Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Signed Text'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $signed
         $result.Status | Should -Be $true
+        $result.ClearText | Should -Be 'Signed Text'
+    }
+
+    It ' Sign and verify detached string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
+        $signature = Protect-PGP -SignOnly -Detached -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Detached Signed Text'
+        $result = Test-PGP -FilePathPublic $KeyPublic -String 'Detached Signed Text' -Signature $signature
+        $result.Status | Should -Be $true
     }
 
     It ' Clear sign and verify string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {
         $clearSigned = Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Clear Signed Text'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $clearSigned -ClearSigned
         $result.Status | Should -Be $true
+        $result.ClearText | Should -Be 'Clear Signed Text'
     }
 
     It ' Clear sign verification fails with the wrong public key' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic1 } {
@@ -77,9 +85,21 @@
     It ' Clear sign and verify file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt')
         $signedFile = [io.path]::Combine($KeysDirectory, 'clear-sign-input.txt.asc')
+        $verifiedFile = [io.path]::Combine($KeysDirectory, 'clear-sign-output.txt')
         Set-Content -Path $sourceFile -Value 'Clear signed file content' -NoNewline
         Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $signedFile -ErrorAction Stop
-        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $signedFile -ClearSigned
+        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $signedFile -ClearSigned -OutFilePath $verifiedFile
+        $result.Status | Should -Be $true
+        $result.OutputPath | Should -Be $verifiedFile
+        Get-Content -LiteralPath $verifiedFile -Raw | Should -Be 'Clear signed file content'
+    }
+
+    It ' Sign and verify detached file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt')
+        $signatureFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt.sig')
+        Set-Content -Path $sourceFile -Value 'Detached signed file content' -NoNewline
+        Protect-PGP -SignOnly -Detached -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $signatureFile -ErrorAction Stop
+        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -SignaturePath $signatureFile
         $result.Status | Should -Be $true
     }
 
@@ -155,6 +175,7 @@
         $signedResult.IsEncrypted | Should -Be $false
         $encryptedResult.IsEncrypted | Should -Be $true
         $encryptedResult.IsSigned | Should -Be $false
+        $encryptedResult.RecipientKeyIds.Count | Should -BeGreaterThan 0
         $inspectErrors.Count | Should -Be 0
     }
 
@@ -179,6 +200,17 @@
 
         $inspection.IsEncrypted | Should -Be $true
         $inspection.IsIntegrityProtected | Should -Be $true
+    }
+
+    It ' Running New-PGPKey with advanced generation options creates expiring keys' -TestCases @{ KeysDirectory = $KeysDirectory } {
+        $advancedPublic = [io.path]::Combine($KeysDirectory, 'AdvancedPublic.asc')
+        $advancedPrivate = [io.path]::Combine($KeysDirectory, 'AdvancedPrivate.asc')
+        New-PGPKey -FilePathPublic $advancedPublic -FilePathPrivate $advancedPrivate -UserName 'advanced@example.test' -Password 'Advanced123!' -Strength 1024 -Certainty 8 -EmitVersion -KeyExpirationInSeconds 3600 -SignatureExpirationInSeconds 3600 -PreferredHashAlgorithm Sha256,Sha512 -PreferredCompressionAlgorithm Zip -PreferredSymmetricKeyAlgorithm Aes256 -ErrorAction Stop
+
+        Test-Path -LiteralPath $advancedPublic | Should -Be $true
+        Test-Path -LiteralPath $advancedPrivate | Should -Be $true
+        $info = Get-PGPKeyInfo -FilePath $advancedPublic
+        $info.Expiration | Should -Not -BeNullOrEmpty
     }
 
     It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -94,6 +94,46 @@
         Get-Content -LiteralPath $verifiedFile -Raw | Should -Be 'Clear signed file content'
     }
 
+    It ' Test-PGP does not write verified output for encrypted-only files' -TestCases @{ KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $sourceFile = [io.path]::Combine($KeysDirectory, 'verify-encrypted-only-input.txt')
+        $encryptedFile = [io.path]::Combine($KeysDirectory, 'verify-encrypted-only-input.txt.pgp')
+        $verifiedFile = [io.path]::Combine($KeysDirectory, 'verify-encrypted-only-output.txt')
+        Set-Content -Path $sourceFile -Value 'Encrypted only file content' -NoNewline
+        Protect-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -OutFilePath $encryptedFile -ErrorAction Stop
+
+        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $encryptedFile -OutFilePath $verifiedFile
+
+        $result.Status | Should -Be $false
+        $result.OutputPath | Should -BeNullOrEmpty
+        $result.Error | Should -Not -BeNullOrEmpty
+        Test-Path -LiteralPath $verifiedFile | Should -Be $false
+    }
+
+    It ' Test-PGP preserves relative paths for folder verification output' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $inputFolder = [io.path]::Combine($KeysDirectory, 'verify-folder-input')
+        $outputFolder = [io.path]::Combine($KeysDirectory, 'verify-folder-output')
+        $folderA = [io.path]::Combine($inputFolder, 'a')
+        $folderB = [io.path]::Combine($inputFolder, 'b')
+        $sourceA = [io.path]::Combine($KeysDirectory, 'verify-folder-a.txt')
+        $sourceB = [io.path]::Combine($KeysDirectory, 'verify-folder-b.txt')
+        $signedA = [io.path]::Combine($folderA, 'report.txt.asc')
+        $signedB = [io.path]::Combine($folderB, 'report.txt.asc')
+        New-Item -ItemType Directory -Path $folderA,$folderB,$outputFolder -Force | Out-Null
+        Set-Content -Path $sourceA -Value 'Folder A report' -NoNewline
+        Set-Content -Path $sourceB -Value 'Folder B report' -NoNewline
+        Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceA -OutFilePath $signedA -ErrorAction Stop
+        Protect-PGP -ClearSign -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceB -OutFilePath $signedB -ErrorAction Stop
+
+        $results = Test-PGP -FilePathPublic $KeyPublic -FolderPath $inputFolder -OutputFolderPath $outputFolder -ClearSigned
+
+        $results.Count | Should -Be 2
+        $results.Status | Should -Be @($true, $true)
+        $outputA = [io.path]::Combine($outputFolder, 'a', 'report.txt')
+        $outputB = [io.path]::Combine($outputFolder, 'b', 'report.txt')
+        Get-Content -LiteralPath $outputA -Raw | Should -Be 'Folder A report'
+        Get-Content -LiteralPath $outputB -Raw | Should -Be 'Folder B report'
+    }
+
     It ' Sign and verify detached file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt')
         $signatureFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt.sig')

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -97,10 +97,13 @@
     It ' Sign and verify detached file' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
         $sourceFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt')
         $signatureFile = [io.path]::Combine($KeysDirectory, 'detached-input.txt.sig')
+        $verifiedFile = [io.path]::Combine($KeysDirectory, 'detached-output.txt')
         Set-Content -Path $sourceFile -Value 'Detached signed file content' -NoNewline
         Protect-PGP -SignOnly -Detached -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -FilePath $sourceFile -OutFilePath $signatureFile -ErrorAction Stop
-        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -SignaturePath $signatureFile
+        $result = Test-PGP -FilePathPublic $KeyPublic -FilePath $sourceFile -SignaturePath $signatureFile -OutFilePath $verifiedFile
         $result.Status | Should -Be $true
+        $result.OutputPath | Should -BeNullOrEmpty
+        Test-Path -LiteralPath $verifiedFile | Should -Be $false
     }
 
     It ' Encrypt and decrypt string symmetrically' {
@@ -213,11 +216,29 @@
         $info.Expiration | Should -Not -BeNullOrEmpty
     }
 
+    It ' Running New-PGPKey rejects binary key upload' -TestCases @{ KeysDirectory = $KeysDirectory } {
+        $advancedPublic = [io.path]::Combine($KeysDirectory, 'BinaryUploadPublic.asc')
+        $advancedPrivate = [io.path]::Combine($KeysDirectory, 'BinaryUploadPrivate.asc')
+
+        {
+            New-PGPKey -FilePathPublic $advancedPublic -FilePathPrivate $advancedPrivate -UserName 'binary-upload@example.test' -Password 'Advanced123!' -Strength 1024 -Certainty 8 -Armor:$false -UploadKeyServer 'https://keys.openpgp.org' -ErrorAction Stop
+        } | Should -Throw -ExpectedMessage '*requires armored public key output*'
+    }
+
     It ' Test-PGP can flag encrypted content when ThrowIfEncrypted is used' -TestCases @{ KeyPublic = $KeyPublic } {
         $protected = Protect-PGP -FilePathPublic $KeyPublic -String 'Encrypted but unsigned'
         $result = Test-PGP -FilePathPublic $KeyPublic -String $protected -ThrowIfEncrypted
         $result.Status | Should -Be $false
         $result.Error | Should -Not -BeNullOrEmpty
+    }
+
+    It ' Test-PGP aborts verification when any public key is missing' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic; KeysDirectory = $KeysDirectory } {
+        $missingKey = [io.path]::Combine($KeysDirectory, 'MissingPublic.asc')
+        $signed = Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Signed Text'
+
+        $result = Test-PGP -FilePathPublic $KeyPublic,$missingKey -String $signed -WarningAction SilentlyContinue
+
+        $result | Should -BeNullOrEmpty
     }
 
     It ' Encrypt file when public key is UTF-8 BOM encoded' -TestCases @{ KeyPublic = $KeyPublic; KeyPublicBom = $KeyPublicBom; KeysDirectory = $KeysDirectory } {


### PR DESCRIPTION
## Summary

This follow-up PR exposes useful PgpCore 7.2.0 capabilities on top of #62:

- add detached signature creation and verification for strings and files
- return verified clear text/output paths from `Test-PGP`
- expose encrypted recipient key IDs through `Get-PGPInspect`
- surface advanced key-generation options such as expiration and preferred algorithms
- add the explicit `Unprotect-PGP -IgnoreIntegrityCheckFailure` opt-in for legacy/damaged content

## Validation

- `git diff --check`
- `dotnet build Sources\PSPGP.sln -c Release`
- `dotnet build Sources\PSPGP.sln -c Debug`
- `dotnet test Sources\PSPGP.sln -c Release --no-build`
- `pwsh -NoProfile -File .\PSPGP.Tests.ps1`
- `powershell -NoProfile -File .\PSPGP.Tests.ps1`

Stacked on #62 / `codex/pgpcore-7-2-latest`.
