### PR TITLE
Upgrade to PgpCore 8.0 and improve key diagnostics

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,5 +1,11 @@
 ﻿### ChangeLog
 
+#### Unreleased
+- Upgrade PgpCore to 8.0.0 and adopt its AES-256, SHA-256, ZIP compression, and 3072-bit key defaults.
+- Report key IDs, fingerprints, strength, creation time, and key state from `Get-PGPKeyInfo`.
+- Map PgpCore typed failures to actionable PowerShell error categories.
+- Cover secure defaults and compressed signed-message verification in the test suites.
+
 #### 0.1.13 - 2024.09.18
 - Bump PgpCore version to 6.5.1
 - Small improvements

--- a/PSPGP.Tests.ps1
+++ b/PSPGP.Tests.ps1
@@ -43,7 +43,7 @@ foreach ($Module in $PSDInformation.RequiredModules) {
 Write-Color
 
 Import-Module $PSScriptRoot\*.psd1 -Force
-$result = Invoke-Pester -Script $PSScriptRoot\Tests -Verbose -PassThru
+$result = Invoke-Pester -Path $PSScriptRoot\Tests -Verbose -PassThru
 
 if ($result.FailedCount -gt 0) {
     throw "$($result.FailedCount) tests failed."

--- a/PSPGP.Tests.ps1
+++ b/PSPGP.Tests.ps1
@@ -7,8 +7,14 @@ if ($PrimaryModule.Count -ne 1) {
     throw 'More than one PSD1 files detected. Failing tests.'
 }
 $PSDInformation = Import-PowerShellDataFile -Path $PrimaryModule.FullName
+$PesterMinimumVersion = [version] '5.0.0'
+$PesterModule = Get-Module -ListAvailable -Name Pester | Where-Object Version -GE $PesterMinimumVersion | Select-Object -First 1
+if (-not $PesterModule) {
+    Install-Module -Name Pester -MinimumVersion $PesterMinimumVersion -Force -SkipPublisherCheck
+}
+Import-Module Pester -MinimumVersion $PesterMinimumVersion -Force
+
 $RequiredModules = @(
-    'Pester'
     'PSWriteColor'
     if ($PSDInformation.RequiredModules) {
         $PSDInformation.RequiredModules

--- a/PSPGP.psd1
+++ b/PSPGP.psd1
@@ -9,7 +9,7 @@
     DotNetFrameworkVersion = '4.7.2'
     FunctionsToExport      = @()
     GUID                   = 'edbf6d52-2d66-405e-a4d4-d4a95db8fb45'
-    ModuleVersion          = '1.0.1'
+    ModuleVersion          = '1.0.2'
     PowerShellVersion      = '5.1'
     PrivateData            = @{
         PSData = @{

--- a/README.MD
+++ b/README.MD
@@ -27,6 +27,8 @@
 
 - [PgpCore](https://github.com/mattosaurus/PgpCore) - licensed MIT
 
+PSPGP uses PgpCore 8.0. New operations therefore default to AES-256 encryption, SHA-256 hashing, ZIP compression, and 3072-bit keys with a certainty of 24. Existing encrypted data remains readable; set the algorithm parameters explicitly only when an older integration requires legacy output.
+
 CI for this branch runs in GitHub Actions via the `.github/workflows/test-dotnet.yml` and `.github/workflows/test-powershell.yml` workflows.
 
 ## Module surface
@@ -50,7 +52,7 @@ Current capabilities:
 - Create signed, detached-signature, and clear-signed content and verify it with one or more public keys
 - Write verified clear content from signed files to an output path
 - Inspect signed, encrypted, and armored message metadata with `Get-PGPInspect`, including encrypted recipient key IDs when available
-- Download public keys from a key server and inspect local key material
+- Download public keys from a key server and inspect local key IDs, fingerprints, size, creation and expiration dates, and key state
 - Generate new key pairs and optionally upload the public key
 
 The checked-in sample assets under `Examples\Keys` use the `PublicPGP1.asc` / `PrivatePGP1.asc` naming pattern.
@@ -79,6 +81,8 @@ PSPGP supports Windows PowerShell 5.1 and PowerShell 7+.
 
 On Windows PowerShell 5.1, the module requires **.NET Framework 4.7.2** or newer. On PowerShell 7+, the module works cross-platform on Windows, Linux, and macOS.
 
+PgpCore 8 also provides typed errors for invalid key material, wrong passphrases, missing keys, unsupported input, and integrity failures. PSPGP maps these to PowerShell error categories such as `InvalidData`, `AuthenticationError`, `ObjectNotFound`, and `SecurityError`, making `try`/`catch` and `$Error` inspection more useful.
+
 ## Using
 
 ### Create new PGP Public/Private Keys
@@ -86,7 +90,7 @@ On Windows PowerShell 5.1, the module requires **.NET Framework 4.7.2** or newer
 ```powershell
 New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
 
-New-PGPKey -FilePathPublic $PSScriptRoot\Keys\ExpiringPublic.asc -FilePathPrivate $PSScriptRoot\Keys\ExpiringPrivate.asc -UserName 'user@example.com' -Password 'secret' -Strength 4096 -Certainty 8 -KeyExpirationInSeconds 31536000 -PreferredHashAlgorithm Sha256,Sha512 -PreferredSymmetricKeyAlgorithm Aes256
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\ExpiringPublic.asc -FilePathPrivate $PSScriptRoot\Keys\ExpiringPrivate.asc -UserName 'user@example.com' -Password 'secret' -Strength 4096 -Certainty 24 -KeyExpirationInSeconds 31536000 -PreferredHashAlgorithm Sha256,Sha512 -PreferredSymmetricKeyAlgorithm Aes256
 ```
 
 ### Encrypt Folder
@@ -177,7 +181,8 @@ When `-Verify` is used with file output, PSPGP writes decrypted content through 
 
 ```powershell
 Get-PGPKey -KeyServer 'https://keys.openpgp.org' -Search 'user@example.com'
-Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
+$KeyInfo = Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
+$KeyInfo | Select-Object KeyId, Fingerprint, Algorithm, BitStrength, CreationTime, Expiration, IsEncryptionKey, IsRevoked
 New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user@example.com' -Password 'secret' -UploadKeyServer 'https://keys.openpgp.org'
 ```
 

--- a/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
+++ b/Sources/PSPGP.Tests/KeyMaterialHelperTests.cs
@@ -36,27 +36,4 @@ public class KeyMaterialHelperTests {
 
         decrypted.Should().Be(originalText);
     }
-
-    [Fact]
-    public void Normalize_WithPacketType20Error_ShouldReturnAeadGuidance() {
-        var exception = new IOException("unknown packet type encountered: 20");
-
-        Exception normalized = PgpExceptionHelper.Normalize(exception);
-
-        normalized.Should().BeOfType<NotSupportedException>();
-        normalized.Message.Should().Contain("AEAD");
-        normalized.InnerException.Should().BeSameAs(exception);
-    }
-
-    [Fact]
-    public void Normalize_WithWrappedPacketType20Error_ShouldReturnAeadGuidance() {
-        var innerException = new IOException("unknown packet type encountered: 20");
-        var exception = new InvalidDataException("encrypted data was not readable", innerException);
-
-        Exception normalized = PgpExceptionHelper.Normalize(exception);
-
-        normalized.Should().BeOfType<NotSupportedException>();
-        normalized.Message.Should().Contain("AEAD");
-        normalized.InnerException.Should().BeSameAs(exception);
-    }
 }

--- a/Sources/PSPGP.Tests/PGPConfiguratorTests.cs
+++ b/Sources/PSPGP.Tests/PGPConfiguratorTests.cs
@@ -24,6 +24,9 @@ public class PGPConfiguratorTests {
             PGPConfigurator.Configure(pgp, null, null, null, null, null, null));
 
         exception.Should().BeNull("Configuration with null parameters should not throw");
+        pgp.HashAlgorithmTag.Should().Be(Org.BouncyCastle.Bcpg.HashAlgorithmTag.Sha256);
+        pgp.CompressionAlgorithm.Should().Be(Org.BouncyCastle.Bcpg.CompressionAlgorithmTag.Zip);
+        pgp.SymmetricKeyAlgorithm.Should().Be(Org.BouncyCastle.Bcpg.SymmetricKeyAlgorithmTag.Aes256);
     }
 
     /// <summary>
@@ -59,7 +62,7 @@ public class PGPConfiguratorTests {
         var action = () => PGPConfigurator.Configure(null,
             Org.BouncyCastle.Bcpg.HashAlgorithmTag.Sha256, null, null, null, null, null);
 
-        action.Should().Throw<NullReferenceException>()
-            .WithMessage("Object reference not set to an instance of an object.");
+        action.Should().Throw<ArgumentNullException>()
+            .WithParameterName("pgp");
     }
 }

--- a/Sources/PSPGP.Tests/PGPIntegrationTests.cs
+++ b/Sources/PSPGP.Tests/PGPIntegrationTests.cs
@@ -1,4 +1,5 @@
 using FluentAssertions;
+using Org.BouncyCastle.Bcpg.OpenPgp;
 using PgpCore;
 using System;
 using System.IO;
@@ -42,6 +43,10 @@ public class PGPCoreIntegrationTests : IDisposable {
         createKeysAction.Should().NotThrow("Key creation should succeed");
         File.Exists(publicKeyPath).Should().BeTrue("Public key should exist");
         File.Exists(privateKeyPath).Should().BeTrue("Private key should exist");
+
+        PgpPublicKey generatedKey = ReadMasterPublicKey(publicKeyPath);
+        generatedKey.BitStrength.Should().Be(3072, "PgpCore v8 generates stronger keys by default");
+        generatedKey.IsEncryptionKey.Should().BeTrue();
 
         // Configure PGP with the generated keys for encryption/decryption
         var encryptionKeys = new EncryptionKeys(new FileInfo(publicKeyPath));
@@ -187,5 +192,19 @@ public class PGPCoreIntegrationTests : IDisposable {
         } catch {
             // Ignore cleanup errors
         }
+    }
+
+    private static PgpPublicKey ReadMasterPublicKey(string path) {
+        using Stream stream = File.OpenRead(path);
+        var bundle = new PgpPublicKeyRingBundle(PgpUtilities.GetDecoderStream(stream));
+        foreach (PgpPublicKeyRing ring in bundle.GetKeyRings()) {
+            foreach (PgpPublicKey key in ring.GetPublicKeys()) {
+                if (key.IsMasterKey) {
+                    return key;
+                }
+            }
+        }
+
+        throw new InvalidDataException($"No master public key was found in '{path}'.");
     }
 }

--- a/Sources/PSPGP.Tests/PgpExceptionHelperTests.cs
+++ b/Sources/PSPGP.Tests/PgpExceptionHelperTests.cs
@@ -62,4 +62,14 @@ public class PgpExceptionHelperTests {
         normalized.Message.Should().Contain("AEAD");
         normalized.InnerException.Should().BeSameAs(exception);
     }
+
+    [Fact]
+    public void GetErrorCategory_WithNormalizedWrappedPacketType20Error_ReturnsNotImplementedCategory() {
+        var innerException = new IOException("unknown packet type encountered: 20");
+        var exception = new InvalidDataException("encrypted data was not readable", innerException);
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception);
+
+        PgpExceptionHelper.GetErrorCategory(normalized).Should().Be(ErrorCategory.NotImplemented);
+    }
 }

--- a/Sources/PSPGP.Tests/PgpExceptionHelperTests.cs
+++ b/Sources/PSPGP.Tests/PgpExceptionHelperTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using PgpCore;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Management.Automation;
+using Xunit;
+
+namespace PSPGP.Tests;
+
+public class PgpExceptionHelperTests {
+    public static IEnumerable<object[]> TypedErrorCategories() {
+        yield return new object[] { new IncorrectPassphraseException("wrong passphrase"), ErrorCategory.AuthenticationError };
+        yield return new object[] { new MessageIntegrityException("integrity check failed"), ErrorCategory.SecurityError };
+        yield return new object[] { new InvalidKeyMaterialException("invalid key"), ErrorCategory.InvalidData };
+        yield return new object[] { new NotEncryptedDataException("not encrypted"), ErrorCategory.InvalidData };
+        yield return new object[] { new NoDecryptionKeyException("missing key"), ErrorCategory.ObjectNotFound };
+        yield return new object[] {
+            new InvalidDataException("wrapper", new IncorrectPassphraseException("wrong passphrase")),
+            ErrorCategory.AuthenticationError
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(TypedErrorCategories))]
+    public void GetErrorCategory_WithPgpCoreTypedException_ReturnsActionableCategory(
+        Exception exception,
+        ErrorCategory expectedCategory) {
+        PgpExceptionHelper.GetErrorCategory(exception).Should().Be(expectedCategory);
+    }
+
+    [Fact]
+    public void Normalize_WithTypedInvalidKeyMaterial_AddsKeyPathGuidance() {
+        var exception = new InvalidKeyMaterialException("invalid key material");
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception, "invalid.asc");
+
+        normalized.Should().BeOfType<InvalidDataException>();
+        normalized.Message.Should().Contain("invalid.asc");
+        normalized.InnerException.Should().BeSameAs(exception);
+    }
+
+    [Fact]
+    public void Normalize_WithPacketType20Error_ShouldReturnAeadGuidance() {
+        var exception = new IOException("unknown packet type encountered: 20");
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception);
+
+        normalized.Should().BeOfType<NotSupportedException>();
+        normalized.Message.Should().Contain("AEAD");
+        normalized.InnerException.Should().BeSameAs(exception);
+    }
+
+    [Fact]
+    public void Normalize_WithWrappedPacketType20Error_ShouldReturnAeadGuidance() {
+        var innerException = new IOException("unknown packet type encountered: 20");
+        var exception = new InvalidDataException("encrypted data was not readable", innerException);
+
+        Exception normalized = PgpExceptionHelper.Normalize(exception);
+
+        normalized.Should().BeOfType<NotSupportedException>();
+        normalized.Message.Should().Contain("AEAD");
+        normalized.InnerException.Should().BeSameAs(exception);
+    }
+}

--- a/Sources/PSPGP/CmdletGetPGPInspect.cs
+++ b/Sources/PSPGP/CmdletGetPGPInspect.cs
@@ -51,7 +51,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
                             GetRecipientKeyIds(() => pgp.GetFileRecipients(fileInfo)),
                             TryGetIntegrityProtected(fileInfo)));
                     } catch (System.Exception ex) {
-                        WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, file));
+                        WriteError(PgpExceptionHelper.CreateErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", file));
                     }
                 }
             } else if (ParameterSetName == "File") {
@@ -70,7 +70,7 @@ public class CmdletGetPGPInspect : PSCmdlet {
                     TryGetIntegrityProtected(String)));
             }
         } catch (System.Exception ex) {
-            WriteError(new ErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed", ErrorCategory.NotSpecified, null));
+            WriteError(PgpExceptionHelper.CreateErrorRecord(NormalizeInspectException(ex), "GetPGPInspectFailed"));
         }
     }
 

--- a/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
+++ b/Sources/PSPGP/CmdletGetPGPKeyInfo.cs
@@ -89,16 +89,23 @@ public class CmdletGetPGPKeyInfo : PSCmdlet {
                         : publicKey.CreationTime.AddSeconds(publicKey.GetValidSeconds());
                     var info = new PGPKeyInfo {
                         FilePath = resolved,
+                        KeyId = $"0x{unchecked((ulong)publicKey.KeyId):X16}",
+                        Fingerprint = BitConverter.ToString(publicKey.GetFingerprint()).Replace("-", string.Empty),
                         UserIds = userIds.ToArray(),
                         Algorithm = publicKey.Algorithm,
-                        Expiration = expiration
+                        BitStrength = publicKey.BitStrength,
+                        CreationTime = publicKey.CreationTime,
+                        Expiration = expiration,
+                        IsMasterKey = publicKey.IsMasterKey,
+                        IsEncryptionKey = publicKey.IsEncryptionKey,
+                        IsRevoked = publicKey.IsRevoked()
                     };
                     WriteObject(info);
                 } else {
                     WriteError(new ErrorRecord(new InvalidDataException($"Cannot read key from {resolved}"), "InvalidKey", ErrorCategory.InvalidData, resolved));
                 }
             } catch (Exception ex) {
-                WriteError(new ErrorRecord(ex, "GetPGPKeyInfoFailed", ErrorCategory.NotSpecified, path));
+                WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "GetPGPKeyInfoFailed", path, path));
             }
         }
     }

--- a/Sources/PSPGP/CmdletNewPGPKey.cs
+++ b/Sources/PSPGP/CmdletNewPGPKey.cs
@@ -15,7 +15,7 @@ namespace PSPGP;
 /// </example>
 /// <example>
 /// <code>
-/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 8 -EmitVersion
+/// New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 24 -EmitVersion
 /// </code>
 /// </example>
 [Cmdlet(VerbsCommon.New, "PGPKey", DefaultParameterSetName = "ClearText")]
@@ -170,7 +170,7 @@ public class CmdletNewPGPKey : PSCmdlet {
                 KeyServerHelper.UploadKeyAsync(new Uri(UploadKeyServer), keyData).GetAwaiter().GetResult();
             }
         } catch (Exception ex) {
-            WriteError(new ErrorRecord(ex, "NewPGPKeyFailed", ErrorCategory.NotSpecified, null));
+            WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "NewPGPKeyFailed"));
         }
     }
 

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -329,7 +329,7 @@ public class CmdletProtectPGP : PSCmdlet {
                 keyPath = FilePathPublic[0];
             }
 
-            WriteError(new ErrorRecord(PgpExceptionHelper.Normalize(ex, keyPath), "ProtectPGPFailed", ErrorCategory.NotSpecified, null));
+            WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "ProtectPGPFailed", keyPath, keyPath));
         } finally {
             signKeyStream?.Dispose();
             foreach (Stream stream in publicKeyStreams) {

--- a/Sources/PSPGP/CmdletProtectPGP.cs
+++ b/Sources/PSPGP/CmdletProtectPGP.cs
@@ -324,9 +324,11 @@ public class CmdletProtectPGP : PSCmdlet {
                 }
             }
         } catch (Exception ex) {
-            string keyPath = SignKey?.FullName;
-            if (keyPath is null && FilePathPublic != null && FilePathPublic.Length > 0) {
+            string keyPath = null;
+            if (SignKey is null && FilePathPublic != null && FilePathPublic.Length == 1) {
                 keyPath = FilePathPublic[0];
+            } else if (SignKey != null && (FilePathPublic is null || FilePathPublic.Length == 0)) {
+                keyPath = SignKey.FullName;
             }
 
             WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "ProtectPGPFailed", keyPath, keyPath));

--- a/Sources/PSPGP/CmdletTestPGP.cs
+++ b/Sources/PSPGP/CmdletTestPGP.cs
@@ -117,7 +117,7 @@ public class CmdletTestPGP : PSCmdlet {
                 WriteObject(VerifyStringWithAnyKey(String, Signature, publicKeys));
             }
         } catch (Exception ex) {
-            WriteError(new ErrorRecord(ex, "TestPGPFailed", ErrorCategory.NotSpecified, null));
+            WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "TestPGPFailed"));
         }
     }
 

--- a/Sources/PSPGP/CmdletUnprotectPGP.cs
+++ b/Sources/PSPGP/CmdletUnprotectPGP.cs
@@ -231,10 +231,10 @@ public class CmdletUnprotectPGP : PSCmdlet {
                         }
 
                         if (!decrypted) {
-                            WriteError(new ErrorRecord(lastError, "DecryptFileFailed", ErrorCategory.NotSpecified, file));
+                            WriteError(PgpExceptionHelper.CreateErrorRecord(lastError, "DecryptFileFailed", file));
                         }
                     } catch (Exception ex) {
-                        WriteError(new ErrorRecord(ex, "DecryptFileFailed", ErrorCategory.NotSpecified, file));
+                        WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "DecryptFileFailed", file));
                         return;
                     }
                 }
@@ -281,10 +281,10 @@ public class CmdletUnprotectPGP : PSCmdlet {
                     }
 
                     if (!decrypted) {
-                        WriteError(new ErrorRecord(lastError, "DecryptFileFailed", ErrorCategory.NotSpecified, FilePath));
+                        WriteError(PgpExceptionHelper.CreateErrorRecord(lastError, "DecryptFileFailed", FilePath));
                     }
                 } catch (Exception ex) {
-                    WriteError(new ErrorRecord(ex, "DecryptFileFailed", ErrorCategory.NotSpecified, FilePath));
+                    WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "DecryptFileFailed", FilePath));
                     return;
                 }
             } else if (ParameterSetName.StartsWith("String")) {
@@ -328,14 +328,14 @@ public class CmdletUnprotectPGP : PSCmdlet {
                     if (decrypted) {
                         WriteObject(result);
                     } else {
-                        WriteError(new ErrorRecord(lastError, "DecryptStringFailed", ErrorCategory.NotSpecified, null));
+                        WriteError(PgpExceptionHelper.CreateErrorRecord(lastError, "DecryptStringFailed"));
                     }
                 } catch (Exception ex) {
-                    WriteError(new ErrorRecord(ex, "DecryptStringFailed", ErrorCategory.NotSpecified, null));
+                    WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "DecryptStringFailed"));
                 }
             }
         } catch (Exception ex) {
-            WriteError(new ErrorRecord(ex, "UnprotectPGPFailed", ErrorCategory.NotSpecified, null));
+            WriteError(PgpExceptionHelper.CreateErrorRecord(ex, "UnprotectPGPFailed"));
         }
     }
 

--- a/Sources/PSPGP/PGPConfigurator.cs
+++ b/Sources/PSPGP/PGPConfigurator.cs
@@ -1,5 +1,6 @@
 using Org.BouncyCastle.Bcpg;
 using PgpCore;
+using System;
 
 namespace PSPGP;
 
@@ -24,6 +25,7 @@ public static class PGPConfigurator {
     /// <param name="signatureType">Signature type when signing.</param>
     /// <param name="publicKeyAlgorithm">Public key algorithm for key creation.</param>
     /// <param name="symmetricKeyAlgorithm">Symmetric key algorithm for encryption.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="pgp"/> is <c>null</c>.</exception>
     public static void Configure(
         PGP pgp,
         HashAlgorithmTag? hashAlgorithm,
@@ -32,6 +34,8 @@ public static class PGPConfigurator {
         int? signatureType,
         PublicKeyAlgorithmTag? publicKeyAlgorithm,
         SymmetricKeyAlgorithmTag? symmetricKeyAlgorithm) {
+        if (pgp is null) throw new ArgumentNullException(nameof(pgp));
+
         if (hashAlgorithm.HasValue) pgp.HashAlgorithmTag = hashAlgorithm.Value;
         if (compressionAlgorithm.HasValue) pgp.CompressionAlgorithm = compressionAlgorithm.Value;
         if (fileType.HasValue) pgp.FileType = fileType.Value;
@@ -40,4 +44,3 @@ public static class PGPConfigurator {
         if (symmetricKeyAlgorithm.HasValue) pgp.SymmetricKeyAlgorithm = symmetricKeyAlgorithm.Value;
     }
 }
-

--- a/Sources/PSPGP/PGPKeyInfo.cs
+++ b/Sources/PSPGP/PGPKeyInfo.cs
@@ -10,13 +10,33 @@ public class PGPKeyInfo {
     /// <summary>Path to the inspected key file.</summary>
     public string FilePath { get; set; }
 
+    /// <summary>OpenPGP key identifier formatted as a 16-digit hexadecimal value.</summary>
+    public string KeyId { get; set; }
+
+    /// <summary>Full OpenPGP key fingerprint formatted as hexadecimal.</summary>
+    public string Fingerprint { get; set; }
+
     /// <summary>User identifiers embedded in the key.</summary>
     public string[] UserIds { get; set; }
 
     /// <summary>Algorithm used to create the key.</summary>
     public PublicKeyAlgorithmTag Algorithm { get; set; }
 
+    /// <summary>Key strength in bits.</summary>
+    public int BitStrength { get; set; }
+
+    /// <summary>Date and time when the key was created.</summary>
+    public DateTime CreationTime { get; set; }
+
     /// <summary>Expiration date of the key if specified.</summary>
     public DateTime? Expiration { get; set; }
-}
 
+    /// <summary>Indicates whether this is the master key in its key ring.</summary>
+    public bool IsMasterKey { get; set; }
+
+    /// <summary>Indicates whether the key is suitable for encryption.</summary>
+    public bool IsEncryptionKey { get; set; }
+
+    /// <summary>Indicates whether the key has been revoked.</summary>
+    public bool IsRevoked { get; set; }
+}

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -12,7 +12,7 @@
 
     <ItemGroup>
         <PackageReference Include="BouncyCastle.Cryptography" Version="2.6.2" />
-        <PackageReference Include="PgpCore" Version="7.2.0" />
+        <PackageReference Include="PgpCore" Version="8.0.0" />
         <PackageReference Include="PowerShellStandard.Library" Version="5.1.1" PrivateAssets="all" />
     </ItemGroup>
 

--- a/Sources/PSPGP/PgpExceptionHelper.cs
+++ b/Sources/PSPGP/PgpExceptionHelper.cs
@@ -1,12 +1,46 @@
+using PgpCore;
 using System;
 using System.IO;
+using System.Management.Automation;
 
 namespace PSPGP;
 
 internal static class PgpExceptionHelper {
-    internal static Exception Normalize(Exception exception, string keyPath = null) {
-        string message = exception?.Message ?? string.Empty;
+    /// <summary>
+    /// Creates a PowerShell error record from a PgpCore or platform exception,
+    /// preserving useful key-path guidance and assigning an actionable category.
+    /// </summary>
+    internal static ErrorRecord CreateErrorRecord(
+        Exception exception,
+        string errorId,
+        object targetObject = null,
+        string keyPath = null) {
+        Exception normalized = Normalize(exception, keyPath);
+        return new ErrorRecord(normalized, errorId, GetErrorCategory(normalized), targetObject);
+    }
 
+    /// <summary>
+    /// Maps typed PgpCore failures and common platform failures to PowerShell error categories.
+    /// Typed PgpCore failures take precedence over generic wrapper exceptions.
+    /// </summary>
+    internal static ErrorCategory GetErrorCategory(Exception exception) {
+        if (ContainsException<IncorrectPassphraseException>(exception)) return ErrorCategory.AuthenticationError;
+        if (ContainsException<MessageIntegrityException>(exception)) return ErrorCategory.SecurityError;
+        if (ContainsException<InvalidKeyMaterialException>(exception) ||
+            ContainsException<NotEncryptedDataException>(exception) ||
+            ContainsException<InvalidDataException>(exception)) return ErrorCategory.InvalidData;
+        if (ContainsException<MissingKeyException>(exception) ||
+            ContainsException<FileNotFoundException>(exception)) return ErrorCategory.ObjectNotFound;
+        if (ContainsException<NotSupportedException>(exception)) return ErrorCategory.NotImplemented;
+        if (ContainsException<UnauthorizedAccessException>(exception)) return ErrorCategory.PermissionDenied;
+
+        return ErrorCategory.NotSpecified;
+    }
+
+    /// <summary>
+    /// Adds PSPGP-specific guidance to failures that PgpCore cannot make actionable on its own.
+    /// </summary>
+    internal static Exception Normalize(Exception exception, string keyPath = null) {
         if (ContainsMessage(exception, "unknown packet type encountered: 20")) {
             return new NotSupportedException(
                 "The encrypted content appears to use OpenPGP AEAD (packet type 20), which the underlying PgpCore/BouncyCastle stack cannot decrypt yet. Re-encrypt the file without AEAD, or remove the AEAD preference from the key before creating new encrypted content.",
@@ -14,15 +48,26 @@ internal static class PgpExceptionHelper {
         }
 
         if (!string.IsNullOrEmpty(keyPath) &&
-            (message.IndexOf("invalid armor header", StringComparison.OrdinalIgnoreCase) >= 0 ||
-             message.IndexOf("unknown object in stream", StringComparison.OrdinalIgnoreCase) >= 0 ||
-             message.IndexOf("Premature end of stream in PartialInputStream", StringComparison.OrdinalIgnoreCase) >= 0)) {
+            (ContainsException<InvalidKeyMaterialException>(exception) ||
+             ContainsMessage(exception, "invalid armor header") ||
+             ContainsMessage(exception, "unknown object in stream") ||
+             ContainsMessage(exception, "Premature end of stream in PartialInputStream"))) {
             return new InvalidDataException(
                 $"The PGP key file '{keyPath}' could not be parsed. If it is ASCII-armored, re-export or save it as plain UTF-8 text without BOM or extra wrapper content.",
                 exception);
         }
 
         return exception;
+    }
+
+    private static bool ContainsException<TException>(Exception exception) where TException : Exception {
+        for (Exception current = exception; current != null; current = current.InnerException) {
+            if (current is TException) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private static bool ContainsMessage(Exception exception, string value) {

--- a/Sources/PSPGP/PgpExceptionHelper.cs
+++ b/Sources/PSPGP/PgpExceptionHelper.cs
@@ -24,6 +24,7 @@ internal static class PgpExceptionHelper {
     /// Typed PgpCore failures take precedence over generic wrapper exceptions.
     /// </summary>
     internal static ErrorCategory GetErrorCategory(Exception exception) {
+        if (exception is NotSupportedException) return ErrorCategory.NotImplemented;
         if (ContainsException<IncorrectPassphraseException>(exception)) return ErrorCategory.AuthenticationError;
         if (ContainsException<MessageIntegrityException>(exception)) return ErrorCategory.SecurityError;
         if (ContainsException<InvalidKeyMaterialException>(exception) ||

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -1,6 +1,6 @@
 ﻿Describe 'PGP Tests' {
     # prepare things
-    $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')
+    $KeysDirectory = [io.path]::Combine([io.path]::GetTempPath(), 'Keys')
     $KeyPublic = [io.path]::Combine($KeysDirectory, 'PublicPGP.asc')
     $KeyPrivate = [io.path]::Combine($KeysDirectory, 'PrivatePGP.asc')
 
@@ -11,7 +11,7 @@
     [string] $Script:ProtectedString = ''
 
     BeforeAll {
-        $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')
+        $KeysDirectory = [io.path]::Combine([io.path]::GetTempPath(), 'Keys')
         New-Item -Path $KeysDirectory -Force -ItemType Directory
         # Ensure the module is loaded in test context
         if (-not (Get-Module PSPGP)) {
@@ -284,7 +284,7 @@
         $missingKey = [io.path]::Combine($KeysDirectory, 'MissingPublic.asc')
         $signed = Protect-PGP -SignOnly -SignKey $KeyPrivate -SignPassword 'ZielonaMila9!' -String 'Signed Text'
 
-        $result = Test-PGP -FilePathPublic $KeyPublic,$missingKey -String $signed -WarningAction SilentlyContinue
+        $result = Test-PGP -FilePathPublic $KeyPublic,$missingKey -String $signed -ErrorAction Continue -WarningAction SilentlyContinue
 
         $result | Should -BeNullOrEmpty
     }
@@ -358,7 +358,7 @@
     }
     # clean everything
     AfterAll {
-        $KeysDirectory = [io.path]::Combine($env:TEMP, 'Keys')
+        $KeysDirectory = [io.path]::Combine([io.path]::GetTempPath(), 'Keys')
         Remove-Item -Path $KeysDirectory -Recurse -Force
     }
 }

--- a/Tests/PSPGP.Tests.ps1
+++ b/Tests/PSPGP.Tests.ps1
@@ -22,6 +22,13 @@
         New-PGPKey -FilePathPublic $KeyPublic -FilePathPrivate $KeyPrivate -UserName 'przemyslaw.klys' -Password 'ZielonaMila9!'
         Test-Path -LiteralPath $KeyPublic | Should -Be $true
         Test-Path -LiteralPath $KeyPrivate | Should -Be $true
+        $keyInfo = Get-PGPKeyInfo -FilePath $KeyPublic -ErrorAction Stop
+        $keyInfo.BitStrength | Should -Be 3072
+        $keyInfo.KeyId | Should -Match '^0x[0-9A-F]{16}$'
+        $keyInfo.Fingerprint | Should -Match '^[0-9A-F]+$'
+        $keyInfo.IsMasterKey | Should -Be $true
+        $keyInfo.IsEncryptionKey | Should -Be $true
+        $keyInfo.IsRevoked | Should -Be $false
 
         New-PGPKey -FilePathPublic $KeyPublic1 -FilePathPrivate $KeyPrivate1 -UserName 'przemyslaw.klys1' -Password 'ZielonaMila9!1'
         Test-Path -LiteralPath $KeyPublic1 | Should -Be $true
@@ -60,6 +67,7 @@
         $result = Test-PGP -FilePathPublic $KeyPublic -String $signed
         $result.Status | Should -Be $true
         $result.ClearText | Should -Be 'Signed Text'
+        (Get-PGPInspect -String $signed).IsCompressed | Should -Be $true
     }
 
     It ' Sign and verify detached string' -TestCases @{ KeyPrivate = $KeyPrivate; KeyPublic = $KeyPublic } {


### PR DESCRIPTION
## Summary

- upgrade PSPGP to the public PgpCore 8.0.0 package and module version 1.0.2
- expose key identifiers, fingerprints, strength, creation time, and key state from `Get-PGPKeyInfo`
- map typed PgpCore failures to actionable PowerShell error categories
- document and test PgpCore 8 secure defaults and compressed signed-message verification
- update the CI test launcher for current Pester releases across PowerShell 5.1 and 7

## Compatibility

New operations now follow PgpCore 8 defaults: AES-256 encryption, SHA-256 hashing, ZIP compression, and 3072-bit generated keys. Existing encrypted data remains readable; integrations that require legacy output can continue selecting algorithms explicitly.

## Validation

Validated all target frameworks, the .NET and PowerShell test suites, and the signed PSPGP 1.0.2 archive under both PowerShell 7 and Windows PowerShell 5.1 using the public NuGet package.