### PR TITLE
Use PowerForge native documentation

### DIFF
--- a/Build/Build-Module.ps1
+++ b/Build/Build-Module.ps1
@@ -71,13 +71,13 @@
     New-ConfigurationFormat -ApplyTo 'DefaultPSD1', 'OnMergePSD1' -PSD1Style 'Minimal'
 
     # configuration for documentation, at the same time it enables documentation processing
-    New-ConfigurationDocumentation -Enable:$false -PathReadme 'Docs\Readme.md' -Path 'Docs'
+    New-ConfigurationDocumentation -Enable -PathReadme 'Docs\Readme.md' -Path 'Docs' -SyncExternalHelpToProjectRoot
 
     New-ConfigurationImportModule -ImportSelf #-ImportRequiredModules
 
     $newConfigurationBuildSplat = @{
         Enable                            = $true
-        SignModule                        = $true
+        SignModule                        = if ([string]::IsNullOrWhiteSpace($Env:SignModule)) { $true } else { [bool]::Parse($Env:SignModule) }
         MergeModuleOnBuild                = $true
         MergeFunctionsFromApprovedModules = $true
         CertificateThumbprint             = '92e95fb58effa6a4a75e77a33cdd6bfe6dd30f1a'
@@ -93,8 +93,8 @@
         DotSourceLibraries                = $true
         DotSourceClasses                  = $true
         DeleteTargetModuleBeforeBuild     = $true
-        NETBinaryModuleDocumenation       = $true
-        RefreshPSD1Only                   = $true
+        NETBinaryModuleDocumentation      = $true
+        RefreshPSD1Only                   = if ([string]::IsNullOrWhiteSpace($Env:RefreshPSD1Only)) { $false } else { [bool]::Parse($Env:RefreshPSD1Only) }
     }
 
     New-ConfigurationBuild @newConfigurationBuildSplat

--- a/Docs/Get-PGPInspect.md
+++ b/Docs/Get-PGPInspect.md
@@ -1,0 +1,102 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Get-PGPInspect
+## SYNOPSIS
+Inspects PGP content and returns message metadata.
+
+## SYNTAX
+### File (Default)
+```powershell
+Get-PGPInspect -FilePath <string> [<CommonParameters>]
+```
+
+### Folder
+```powershell
+Get-PGPInspect -FolderPath <string> [<CommonParameters>]
+```
+
+### String
+```powershell
+Get-PGPInspect -String <string> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Inspects PGP content and returns message metadata.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String 'Signed text'
+Get-PGPInspect -String $Signature
+```
+
+
+## PARAMETERS
+
+### -FilePath
+File to inspect.
+
+```yaml
+Type: String
+Parameter Sets: File
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FolderPath
+Folder containing PGP files to inspect.
+
+```yaml
+Type: String
+Parameter Sets: Folder
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -String
+Armored message content to inspect.
+
+```yaml
+Type: String
+Parameter Sets: String
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PSPGP.PGPInspectInfo`: Represents the metadata extracted from a PGP message.
+
+## RELATED LINKS
+
+- None

--- a/Docs/Get-PGPKey.md
+++ b/Docs/Get-PGPKey.md
@@ -1,0 +1,91 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Get-PGPKey
+## SYNOPSIS
+Downloads a public key from a key server.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-PGPKey -KeyServer <string> -Search <string> [-OutFilePath <string>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Downloads a public key from a key server.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PGPKey -KeyServer "https://keys.example.com" -Search "user@example.com" -OutFilePath "key.asc"
+```
+
+
+## PARAMETERS
+
+### -KeyServer
+URL of the key server.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutFilePath
+File path where the downloaded key is stored.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Search
+Search string identifying the key.
+
+```yaml
+Type: String
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Docs/Get-PGPKeyInfo.md
+++ b/Docs/Get-PGPKeyInfo.md
@@ -1,0 +1,59 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Get-PGPKeyInfo
+## SYNOPSIS
+Returns information about a PGP key such as algorithm, expiration and user IDs.
+
+## SYNTAX
+### __AllParameterSets
+```powershell
+Get-PGPKeyInfo -FilePath <string[]> [<CommonParameters>]
+```
+
+## DESCRIPTION
+Returns information about a PGP key such as algorithm, expiration and user IDs.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc
+```
+
+
+## PARAMETERS
+
+### -FilePath
+Paths to key files to inspect.
+
+```yaml
+Type: String[]
+Parameter Sets: __AllParameterSets
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: True (ByValue, ByPropertyName)
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `System.String[]`
+
+## OUTPUTS
+
+- `PSPGP.PGPKeyInfo`: Information about a PGP key file.
+
+## RELATED LINKS
+
+- None

--- a/Docs/New-PGPKey.md
+++ b/Docs/New-PGPKey.md
@@ -11,22 +11,22 @@ Generates a new PGP key pair.
 ## SYNTAX
 ### ClearText (Default)
 ```powershell
-New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
 ```
 
 ### Strength
 ```powershell
-New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
 ```
 
 ### StrengthCredential
 ```powershell
-New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
 ```
 
 ### Credential
 ```powershell
-New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> [-UploadKeyServer <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> [-UploadKeyServer <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -84,10 +84,10 @@ Accept wildcard characters: False
 Optional compression algorithm used when generating keys.
 
 ```yaml
-Type: Nullable`1
+Type: CompressionAlgorithmTag
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: None
-Possible values:
+Possible values: Uncompressed, Zip, ZLib, BZip2
 
 Required: False
 Position: named
@@ -164,10 +164,10 @@ Accept wildcard characters: False
 Defines the file type stored within the PGP package.
 
 ```yaml
-Type: Nullable`1
+Type: PGPFileType
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: None
-Possible values:
+Possible values: Binary, Text, UTF8
 
 Required: False
 Position: named
@@ -180,10 +180,10 @@ Accept wildcard characters: False
 Optional hash algorithm used when generating keys.
 
 ```yaml
-Type: Nullable`1
+Type: HashAlgorithmTag
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: HashAlgorithmTag
-Possible values:
+Possible values: MD5, Sha1, RipeMD160, DoubleSha, MD2, Tiger192, Haval5pass160, Sha256, Sha384, Sha512, Sha224, Sha3_256, Sha3_512, MD4, Sha3_224, Sha3_256_Old, Sha3_384, Sha3_512_Old, SM3
 
 Required: False
 Position: named
@@ -228,7 +228,7 @@ Accept wildcard characters: False
 PGP signature type used when creating the key.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: None
 Possible values:
@@ -292,10 +292,10 @@ Accept wildcard characters: False
 Public key algorithm used for key creation.
 
 ```yaml
-Type: Nullable`1
+Type: PublicKeyAlgorithmTag
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: None
-Possible values:
+Possible values: RsaGeneral, RsaEncrypt, RsaSign, ElGamalEncrypt, Dsa, ECDH, ECDsa, ElGamalGeneral, DiffieHellman, EdDsa, EdDsa_Legacy, Experimental_1, Experimental_2, Experimental_3, Experimental_4, Experimental_5, Experimental_6, Experimental_7, Experimental_8, Experimental_9, Experimental_10, Experimental_11
 
 Required: False
 Position: named
@@ -340,10 +340,10 @@ Accept wildcard characters: False
 Symmetric key algorithm used for encryption.
 
 ```yaml
-Type: Nullable`1
+Type: SymmetricKeyAlgorithmTag
 Parameter Sets: ClearText, Strength, StrengthCredential, Credential
 Aliases: None
-Possible values:
+Possible values: Null, Idea, TripleDes, Cast5, Blowfish, Safer, Des, Aes128, Aes192, Aes256, Twofish, Camellia128, Camellia192, Camellia256
 
 Required: False
 Position: named

--- a/Docs/New-PGPKey.md
+++ b/Docs/New-PGPKey.md
@@ -1,0 +1,400 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# New-PGPKey
+## SYNOPSIS
+Generates a new PGP key pair.
+
+## SYNTAX
+### ClearText (Default)
+```powershell
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
+```
+
+### Strength
+```powershell
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-UserName <string>] [-Password <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
+```
+
+### StrengthCredential
+```powershell
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> -Strength <int> -Certainty <int> [-UploadKeyServer <string>] [-EmitVersion] [-Armor <bool>] [-KeyExpirationInSeconds <long>] [-SignatureExpirationInSeconds <long>] [-HashAlgorithm <HashAlgorithmTag>] [-PreferredHashAlgorithm <HashAlgorithmTag[]>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-PreferredCompressionAlgorithm <CompressionAlgorithmTag[]>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-PreferredSymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag[]>] [<CommonParameters>]
+```
+
+### Credential
+```powershell
+New-PGPKey -FilePathPublic <string> -FilePathPrivate <string> -Credential <pscredential> [-UploadKeyServer <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Generates a new PGP key pair.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user' -Password 'secret'
+```
+
+
+### EXAMPLE 2
+```powershell
+New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 24 -EmitVersion
+```
+
+
+## PARAMETERS
+
+### -Armor
+Controls whether generated key files are ASCII armored.
+
+```yaml
+Type: Boolean
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Certainty
+Certainty value used when generating a key.
+
+```yaml
+Type: Int32
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressionAlgorithm
+Optional compression algorithm used when generating keys.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+Credential object providing user name and password.
+
+```yaml
+Type: PSCredential
+Parameter Sets: StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EmitVersion
+Adds the PGP version notation to the key.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPrivate
+Path to the private key file to create.
+
+```yaml
+Type: String
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPublic
+Path to the public key file to create.
+
+```yaml
+Type: String
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileType
+Defines the file type stored within the PGP package.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HashAlgorithm
+Optional hash algorithm used when generating keys.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: HashAlgorithmTag
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -KeyExpirationInSeconds
+Key expiration in seconds. Use zero for no expiration.
+
+```yaml
+Type: Int64
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password used to protect the private key.
+
+```yaml
+Type: String
+Parameter Sets: ClearText, Strength
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PgpSignatureType
+PGP signature type used when creating the key.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredCompressionAlgorithm
+Preferred compression algorithms advertised by the generated key.
+
+```yaml
+Type: CompressionAlgorithmTag[]
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values: Uncompressed, Zip, ZLib, BZip2
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredHashAlgorithm
+Preferred hash algorithms advertised by the generated key.
+
+```yaml
+Type: HashAlgorithmTag[]
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values: MD5, Sha1, RipeMD160, DoubleSha, MD2, Tiger192, Haval5pass160, Sha256, Sha384, Sha512, Sha224, Sha3_256, Sha3_512, MD4, Sha3_224, Sha3_256_Old, Sha3_384, Sha3_512_Old, SM3
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PreferredSymmetricKeyAlgorithm
+Preferred symmetric algorithms advertised by the generated key.
+
+```yaml
+Type: SymmetricKeyAlgorithmTag[]
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values: Null, Idea, TripleDes, Cast5, Blowfish, Safer, Des, Aes128, Aes192, Aes256, Twofish, Camellia128, Camellia192, Camellia256
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PublicKeyAlgorithm
+Public key algorithm used for key creation.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SignatureExpirationInSeconds
+Signature expiration in seconds. Use zero for no expiration.
+
+```yaml
+Type: Int64
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Strength
+Key strength in bits.
+
+```yaml
+Type: Int32
+Parameter Sets: Strength, StrengthCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SymmetricKeyAlgorithm
+Symmetric key algorithm used for encryption.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UploadKeyServer
+Key server URL to upload the generated public key.
+
+```yaml
+Type: String
+Parameter Sets: ClearText, Strength, StrengthCredential, Credential
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UserName
+User name associated with the generated key.
+
+```yaml
+Type: String
+Parameter Sets: ClearText, Strength
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Docs/Protect-PGP.md
+++ b/Docs/Protect-PGP.md
@@ -13,62 +13,62 @@ without encryption. Add -Detached to create a separate detached signature.
 ## SYNTAX
 ### File (Default)
 ```powershell
-Protect-PGP -FilePathPublic <string[]> -FilePath <string> [-OutFilePath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FilePathPublic <string[]> -FilePath <string> [-OutFilePath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### Folder
 ```powershell
-Protect-PGP -FilePathPublic <string[]> -FolderPath <string> [-OutputFolderPath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FilePathPublic <string[]> -FolderPath <string> [-OutputFolderPath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### String
 ```powershell
-Protect-PGP -FilePathPublic <string[]> -String <string> [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FilePathPublic <string[]> -String <string> [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### SignFolder
 ```powershell
-Protect-PGP -FolderPath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+Protect-PGP -FolderPath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
 ```
 
 ### SignFile
 ```powershell
-Protect-PGP -FilePath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+Protect-PGP -FilePath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
 ```
 
 ### SignString
 ```powershell
-Protect-PGP -String <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+Protect-PGP -String <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
 ```
 
 ### ClearSignFolder
 ```powershell
-Protect-PGP -FolderPath <string> -SignKey <FileInfo> -ClearSign [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FolderPath <string> -SignKey <FileInfo> -ClearSign [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### SymmetricFolder
 ```powershell
-Protect-PGP -FolderPath <string> -SymmetricPassphrase <string> [-OutputFolderPath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FolderPath <string> -SymmetricPassphrase <string> [-OutputFolderPath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### ClearSignFile
 ```powershell
-Protect-PGP -FilePath <string> -SignKey <FileInfo> -ClearSign [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FilePath <string> -SignKey <FileInfo> -ClearSign [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### SymmetricFile
 ```powershell
-Protect-PGP -FilePath <string> -SymmetricPassphrase <string> [-OutFilePath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -FilePath <string> -SymmetricPassphrase <string> [-OutFilePath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### ClearSignString
 ```powershell
-Protect-PGP -String <string> -SignKey <FileInfo> -ClearSign [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -String <string> -SignKey <FileInfo> -ClearSign [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ### SymmetricString
 ```powershell
-Protect-PGP -String <string> -SymmetricPassphrase <string> [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+Protect-PGP -String <string> -SymmetricPassphrase <string> [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <Int32>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -168,10 +168,10 @@ Accept wildcard characters: False
 Optional compression algorithm for encryption.
 
 ```yaml
-Type: Nullable`1
+Type: CompressionAlgorithmTag
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: None
-Possible values:
+Possible values: Uncompressed, Zip, ZLib, BZip2
 
 Required: False
 Position: named
@@ -232,10 +232,10 @@ Accept wildcard characters: False
 Type of data being encrypted.
 
 ```yaml
-Type: Nullable`1
+Type: PGPFileType
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: None
-Possible values:
+Possible values: Binary, Text, UTF8
 
 Required: False
 Position: named
@@ -264,10 +264,10 @@ Accept wildcard characters: False
 Optional hash algorithm for encryption.
 
 ```yaml
-Type: Nullable`1
+Type: HashAlgorithmTag
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: HashAlgorithmTag
-Possible values:
+Possible values: MD5, Sha1, RipeMD160, DoubleSha, MD2, Tiger192, Haval5pass160, Sha256, Sha384, Sha512, Sha224, Sha3_256, Sha3_512, MD4, Sha3_224, Sha3_256_Old, Sha3_384, Sha3_512_Old, SM3
 
 Required: False
 Position: named
@@ -360,7 +360,7 @@ Accept wildcard characters: False
 PGP signature type when signing data.
 
 ```yaml
-Type: Nullable`1
+Type: Int32
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: None
 Possible values:
@@ -376,10 +376,10 @@ Accept wildcard characters: False
 Public key algorithm used during encryption.
 
 ```yaml
-Type: Nullable`1
+Type: PublicKeyAlgorithmTag
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: None
-Possible values:
+Possible values: RsaGeneral, RsaEncrypt, RsaSign, ElGamalEncrypt, Dsa, ECDH, ECDsa, ElGamalGeneral, DiffieHellman, EdDsa, EdDsa_Legacy, Experimental_1, Experimental_2, Experimental_3, Experimental_4, Experimental_5, Experimental_6, Experimental_7, Experimental_8, Experimental_9, Experimental_10, Experimental_11
 
 Required: False
 Position: named
@@ -459,10 +459,10 @@ Accept wildcard characters: False
 Symmetric key algorithm used during encryption.
 
 ```yaml
-Type: Nullable`1
+Type: SymmetricKeyAlgorithmTag
 Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
 Aliases: None
-Possible values:
+Possible values: Null, Idea, TripleDes, Cast5, Blowfish, Safer, Des, Aes128, Aes192, Aes256, Twofish, Camellia128, Camellia192, Camellia256
 
 Required: False
 Position: named

--- a/Docs/Protect-PGP.md
+++ b/Docs/Protect-PGP.md
@@ -1,0 +1,519 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Protect-PGP
+## SYNOPSIS
+Encrypts or signs files, folders or strings using one or more public keys.
+Use -SignOnly or the Sign* parameter sets to create signatures
+without encryption. Add -Detached to create a separate detached signature.
+
+## SYNTAX
+### File (Default)
+```powershell
+Protect-PGP -FilePathPublic <string[]> -FilePath <string> [-OutFilePath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### Folder
+```powershell
+Protect-PGP -FilePathPublic <string[]> -FolderPath <string> [-OutputFolderPath <string>] [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### String
+```powershell
+Protect-PGP -FilePathPublic <string[]> -String <string> [-SignKey <FileInfo>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### SignFolder
+```powershell
+Protect-PGP -FolderPath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+```
+
+### SignFile
+```powershell
+Protect-PGP -FilePath <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+```
+
+### SignString
+```powershell
+Protect-PGP -String <string> -SignKey <FileInfo> -SignOnly [-FilePathPublic <string[]>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [-Detached] [<CommonParameters>]
+```
+
+### ClearSignFolder
+```powershell
+Protect-PGP -FolderPath <string> -SignKey <FileInfo> -ClearSign [-OutputFolderPath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### SymmetricFolder
+```powershell
+Protect-PGP -FolderPath <string> -SymmetricPassphrase <string> [-OutputFolderPath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### ClearSignFile
+```powershell
+Protect-PGP -FilePath <string> -SignKey <FileInfo> -ClearSign [-OutFilePath <string>] [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### SymmetricFile
+```powershell
+Protect-PGP -FilePath <string> -SymmetricPassphrase <string> [-OutFilePath <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### ClearSignString
+```powershell
+Protect-PGP -String <string> -SignKey <FileInfo> -ClearSign [-SignPassword <string>] [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+### SymmetricString
+```powershell
+Protect-PGP -String <string> -SymmetricPassphrase <string> [-HashAlgorithm <HashAlgorithmTag>] [-CompressionAlgorithm <CompressionAlgorithmTag>] [-FileType <PGPFileType>] [-PgpSignatureType <int>] [-PublicKeyAlgorithm <PublicKeyAlgorithmTag>] [-SymmetricKeyAlgorithm <SymmetricKeyAlgorithmTag>] [-Armor <bool>] [-WithIntegrityCheck <bool>] [-LiteralFileName <string>] [-Headers <hashtable>] [-OldFormat] [-AddVersionHeader] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Encrypts or signs files, folders or strings using one or more public keys.
+Use -SignOnly or the Sign* parameter sets to create signatures
+without encryption. Add -Detached to create a separate detached signature.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded
+```
+
+
+### EXAMPLE 2
+```powershell
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp
+```
+
+
+### EXAMPLE 3
+```powershell
+Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String "Sensitive text"
+```
+
+
+### EXAMPLE 4
+```powershell
+Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'Sensitive text'
+```
+
+
+### EXAMPLE 5
+```powershell
+Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Signed content"
+```
+
+
+### EXAMPLE 6
+```powershell
+Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Human readable signed content"
+```
+
+
+## PARAMETERS
+
+### -AddVersionHeader
+Adds the PGP version header to generated armored content.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Armor
+Controls whether file output is armored.
+
+```yaml
+Type: Boolean
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ClearSign
+Creates a clear-signed message that remains human readable.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: ClearSignFolder, ClearSignFile, ClearSignString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CompressionAlgorithm
+Optional compression algorithm for encryption.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Detached
+Creates a detached signature over the original input.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: SignFolder, SignFile, SignString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+File to encrypt when using the File parameter set.
+
+```yaml
+Type: String
+Parameter Sets: File, SignFile, ClearSignFile, SymmetricFile
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPublic
+Public key files used for encryption.
+
+```yaml
+Type: String[]
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FileType
+Type of data being encrypted.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FolderPath
+Folder to encrypt when using the Folder parameter set.
+
+```yaml
+Type: String
+Parameter Sets: Folder, SignFolder, ClearSignFolder, SymmetricFolder
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -HashAlgorithm
+Optional hash algorithm for encryption.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: HashAlgorithmTag
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Headers
+Optional armored headers added to generated content.
+
+```yaml
+Type: Hashtable
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -LiteralFileName
+Optional literal file name embedded in the PGP payload.
+
+```yaml
+Type: String
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: Name
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OldFormat
+Uses the legacy packet format when set.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutFilePath
+Output file path for the encrypted file.
+
+```yaml
+Type: String
+Parameter Sets: File, SignFile, ClearSignFile, SymmetricFile
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFolderPath
+Destination folder for encrypted files.
+
+```yaml
+Type: String
+Parameter Sets: Folder, SignFolder, ClearSignFolder, SymmetricFolder
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PgpSignatureType
+PGP signature type when signing data.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PublicKeyAlgorithm
+Public key algorithm used during encryption.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SignKey
+Private key used for signing data. Mandatory when using the
+Sign* parameter sets or the -SignOnly switch.
+
+```yaml
+Type: FileInfo
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, ClearSignFile, ClearSignString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SignOnly
+When specified, only a signature is produced instead of encrypting
+the input. This parameter is automatically implied when using the
+Sign* parameter sets.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: SignFolder, SignFile, SignString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SignPassword
+Password for the signing private key.
+
+```yaml
+Type: String
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, ClearSignFile, ClearSignString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -String
+String content to encrypt.
+
+```yaml
+Type: String
+Parameter Sets: String, SignString, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SymmetricKeyAlgorithm
+Symmetric key algorithm used during encryption.
+
+```yaml
+Type: Nullable`1
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SymmetricPassphrase
+Passphrase used for symmetric encryption.
+
+```yaml
+Type: String
+Parameter Sets: SymmetricFolder, SymmetricFile, SymmetricString
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WithIntegrityCheck
+Controls whether an integrity check packet is added.
+
+```yaml
+Type: Boolean
+Parameter Sets: File, Folder, String, SignFolder, SignFile, SignString, ClearSignFolder, SymmetricFolder, ClearSignFile, SymmetricFile, ClearSignString, SymmetricString
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Docs/Readme.md
+++ b/Docs/Readme.md
@@ -1,0 +1,34 @@
+---
+Module Name: PSPGP
+Module Guid: edbf6d52-2d66-405e-a4d4-d4a95db8fb45
+Download Help Link: https://github.com/EvotecIT/PSPGP
+Help Version: 1.0.2
+Locale: en-US
+---
+# PSPGP Module
+## Description
+PSPGP is a PowerShell module that provides PGP functionality in PowerShell. It allows encrypting and decrypting files/folders and strings using PGP.
+
+## PSPGP Cmdlets
+### [Get-PGPInspect](Get-PGPInspect.md)
+Inspects PGP content and returns message metadata.
+
+### [Get-PGPKey](Get-PGPKey.md)
+Downloads a public key from a key server.
+
+### [Get-PGPKeyInfo](Get-PGPKeyInfo.md)
+Returns information about a PGP key such as algorithm, expiration and user IDs.
+
+### [New-PGPKey](New-PGPKey.md)
+Generates a new PGP key pair.
+
+### [Protect-PGP](Protect-PGP.md)
+Encrypts or signs files, folders or strings using one or more public keys.
+Use -SignOnly or the Sign* parameter sets to create signatures
+without encryption. Add -Detached to create a separate detached signature.
+
+### [Test-PGP](Test-PGP.md)
+Verifies PGP signatures for files, folders or strings.
+
+### [Unprotect-PGP](Unprotect-PGP.md)
+Removes PGP encryption from files or strings using a private key or symmetric passphrase.

--- a/Docs/Test-PGP.md
+++ b/Docs/Test-PGP.md
@@ -1,0 +1,237 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Test-PGP
+## SYNOPSIS
+Verifies PGP signatures for files, folders or strings.
+
+## SYNTAX
+### File (Default)
+```powershell
+Test-PGP -FilePathPublic <string[]> -FilePath <string> [-SignaturePath <string>] [-OutFilePath <string>] [-ThrowIfEncrypted] [-ClearSigned] [<CommonParameters>]
+```
+
+### Folder
+```powershell
+Test-PGP -FilePathPublic <string[]> -FolderPath <string> [-OutputFolderPath <string>] [-ThrowIfEncrypted] [-ClearSigned] [<CommonParameters>]
+```
+
+### String
+```powershell
+Test-PGP -FilePathPublic <string[]> -String <string> [-Signature <string>] [-ThrowIfEncrypted] [-ClearSigned] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Verifies PGP signatures for files, folders or strings.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString
+```
+
+
+### EXAMPLE 2
+```powershell
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Encoded
+```
+
+
+### EXAMPLE 3
+```powershell
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -SignaturePath $PSScriptRoot\Test\Test1.txt.sig
+```
+
+
+### EXAMPLE 4
+```powershell
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned
+```
+
+
+### EXAMPLE 5
+```powershell
+Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString -ThrowIfEncrypted
+```
+
+
+## PARAMETERS
+
+### -ClearSigned
+Verifies clear-signed content instead of regular signed content.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: File, Folder, String
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+File path to verify.
+
+```yaml
+Type: String
+Parameter Sets: File
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPublic
+Public key file used to verify signatures.
+
+```yaml
+Type: String[]
+Parameter Sets: File, Folder, String
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FolderPath
+Folder containing files to verify.
+
+```yaml
+Type: String
+Parameter Sets: Folder
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutFilePath
+Output path for verified clear content.
+
+```yaml
+Type: String
+Parameter Sets: File
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFolderPath
+Destination folder for verified clear content.
+
+```yaml
+Type: String
+Parameter Sets: Folder
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Signature
+Detached signature for the string input.
+
+```yaml
+Type: String
+Parameter Sets: String
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SignaturePath
+Detached signature file for the input file.
+
+```yaml
+Type: String
+Parameter Sets: File
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -String
+Signed text or original text when Signature is provided.
+
+```yaml
+Type: String
+Parameter Sets: String
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ThrowIfEncrypted
+Throws when encrypted content is passed to verify methods.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: File, Folder, String
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `PSPGP.VerificationResult`: Represents the outcome of a signature verification operation.
+
+## RELATED LINKS
+
+- None

--- a/Docs/Unprotect-PGP.md
+++ b/Docs/Unprotect-PGP.md
@@ -1,0 +1,317 @@
+---
+external help file: PSPGP-help.xml
+Module Name: PSPGP
+online version: https://github.com/EvotecIT/PSPGP
+schema: 2.0.0
+---
+# Unprotect-PGP
+## SYNOPSIS
+Removes PGP encryption from files or strings using a private key or symmetric passphrase.
+
+## SYNTAX
+### FolderClearText (Default)
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FolderPath <string> -OutputFolderPath <string> [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FolderCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -Credential <pscredential> -FolderPath <string> -OutputFolderPath <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FileCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -Credential <pscredential> -FilePath <string> -OutFilePath <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FileClearText
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePath <string> -OutFilePath <string> [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### StringClearText
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -String <string> [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### StringCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -Credential <pscredential> -String <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FolderVerifyCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -Credential <pscredential> -FolderPath <string> -OutputFolderPath <string> -Verify [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FolderVerifyClearText
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -FolderPath <string> -OutputFolderPath <string> -Verify [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FileVerifyCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -Credential <pscredential> -FilePath <string> -OutFilePath <string> -Verify [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FileVerifyClearText
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -FilePath <string> -OutFilePath <string> -Verify [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### StringVerifyClearText
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -String <string> -Verify [-Password <string>] [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### StringVerifyCredential
+```powershell
+Unprotect-PGP -FilePathPrivate <string[]> -FilePathPublic <string[]> -Credential <pscredential> -String <string> -Verify [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FolderSymmetric
+```powershell
+Unprotect-PGP -SymmetricPassphrase <string> -FolderPath <string> -OutputFolderPath <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### FileSymmetric
+```powershell
+Unprotect-PGP -SymmetricPassphrase <string> -FilePath <string> -OutFilePath <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+### StringSymmetric
+```powershell
+Unprotect-PGP -SymmetricPassphrase <string> -String <string> [-IgnoreIntegrityCheckFailure] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Removes PGP encryption from files or strings using a private key or symmetric passphrase.
+
+## EXAMPLES
+
+### EXAMPLE 1
+```powershell
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded
+```
+
+
+### EXAMPLE 2
+```powershell
+Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -String $Encrypted
+```
+
+
+### EXAMPLE 3
+```powershell
+Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $Encrypted
+```
+
+
+## PARAMETERS
+
+### -Credential
+Credential object with password for the private key.
+
+```yaml
+Type: PSCredential
+Parameter Sets: FolderCredential, FileCredential, StringCredential, FolderVerifyCredential, FileVerifyCredential, StringVerifyCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+Encrypted file to decrypt.
+
+```yaml
+Type: String
+Parameter Sets: FileCredential, FileClearText, FileVerifyCredential, FileVerifyClearText, FileSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPrivate
+Private key file used to decrypt data.
+
+```yaml
+Type: String[]
+Parameter Sets: FolderClearText, FolderCredential, FileCredential, FileClearText, StringClearText, StringCredential, FolderVerifyCredential, FolderVerifyClearText, FileVerifyCredential, FileVerifyClearText, StringVerifyClearText, StringVerifyCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePathPublic
+Public key files reserved for signed-and-encrypted verification workflows.
+
+```yaml
+Type: String[]
+Parameter Sets: FolderVerifyCredential, FolderVerifyClearText, FileVerifyCredential, FileVerifyClearText, StringVerifyClearText, StringVerifyCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FolderPath
+Folder containing encrypted files.
+
+```yaml
+Type: String
+Parameter Sets: FolderClearText, FolderCredential, FolderVerifyCredential, FolderVerifyClearText, FolderSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -IgnoreIntegrityCheckFailure
+Ignores modification-detection/integrity-check failures during decryption.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FolderClearText, FolderCredential, FileCredential, FileClearText, StringClearText, StringCredential, FolderVerifyCredential, FolderVerifyClearText, FileVerifyCredential, FileVerifyClearText, StringVerifyClearText, StringVerifyCredential, FolderSymmetric, FileSymmetric, StringSymmetric
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutFilePath
+Output file path for decrypted data.
+
+```yaml
+Type: String
+Parameter Sets: FileCredential, FileClearText, FileVerifyCredential, FileVerifyClearText, FileSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputFolderPath
+Destination folder for decrypted output.
+
+```yaml
+Type: String
+Parameter Sets: FolderClearText, FolderCredential, FolderVerifyCredential, FolderVerifyClearText, FolderSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Password
+Password protecting the private key.
+
+```yaml
+Type: String
+Parameter Sets: FolderClearText, FileClearText, StringClearText, FolderVerifyClearText, FileVerifyClearText, StringVerifyClearText
+Aliases: None
+Possible values:
+
+Required: False
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -String
+Encrypted text to decrypt.
+
+```yaml
+Type: String
+Parameter Sets: StringClearText, StringCredential, StringVerifyClearText, StringVerifyCredential, StringSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -SymmetricPassphrase
+Passphrase used for symmetric decryption.
+
+```yaml
+Type: String
+Parameter Sets: FolderSymmetric, FileSymmetric, StringSymmetric
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Verify
+Reserved for future signed-and-encrypted verification support.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: FolderVerifyCredential, FolderVerifyClearText, FileVerifyCredential, FileVerifyClearText, StringVerifyClearText, StringVerifyCredential
+Aliases: None
+Possible values:
+
+Required: True
+Position: named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+- `None`
+
+## OUTPUTS
+
+- `None`
+
+## RELATED LINKS
+
+- None

--- a/Sources/PSPGP/PSPGP.csproj
+++ b/Sources/PSPGP/PSPGP.csproj
@@ -36,23 +36,8 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
+        <!-- PowerForge enriches module help from the compiler XML documentation file. -->
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
     </PropertyGroup>
-
-    <!-- This is needed for XmlDoc2CmdletDoc to generate a PowerShell documentation file. -->
-    <ItemGroup>
-        <PackageReference Include="MatejKafka.XmlDoc2CmdletDoc" Version="0.6.0">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-
-    <!-- Copy help documentation to publish output after publish -->
-    <Target Name="CopyHelpDocumentationToPublishOutput" AfterTargets="Publish">
-        <Copy SourceFiles="$(OutputPath)$(AssemblyName).dll-Help.xml"
-            DestinationFiles="$(PublishDir)$(AssemblyName).dll-Help.xml"
-            Condition="Exists('$(OutputPath)$(AssemblyName).dll-Help.xml')" />
-    </Target>
 
 </Project>

--- a/en-US/PSPGP-help.xml
+++ b/en-US/PSPGP-help.xml
@@ -342,9 +342,15 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional compression algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -378,9 +384,14 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Defines the file type stored within the PGP package.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -390,9 +401,30 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional hash algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -414,9 +446,9 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>PGP signature type used when creating the key.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -426,9 +458,33 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Public key algorithm used for key creation.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -438,9 +494,25 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Symmetric key algorithm used for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -501,9 +573,15 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional compression algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -549,9 +627,14 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Defines the file type stored within the PGP package.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -561,9 +644,30 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional hash algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -597,9 +701,9 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>PGP signature type used when creating the key.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -688,9 +792,33 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Public key algorithm used for key creation.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -724,9 +852,25 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Symmetric key algorithm used for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -787,9 +931,15 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional compression algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -847,9 +997,14 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Defines the file type stored within the PGP package.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -859,9 +1014,30 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional hash algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -883,9 +1059,9 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>PGP signature type used when creating the key.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -974,9 +1150,33 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Public key algorithm used for key creation.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1010,9 +1210,25 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Symmetric key algorithm used for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1037,9 +1253,15 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional compression algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1085,9 +1307,14 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Defines the file type stored within the PGP package.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1097,9 +1324,30 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Optional hash algorithm used when generating keys.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1109,9 +1357,9 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>PGP signature type used when creating the key.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1121,9 +1369,33 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Public key algorithm used for key creation.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1133,9 +1405,25 @@ Get-PGPInspect -String $Signature</dev:code>
           <maml:description>
             <maml:para>Symmetric key algorithm used for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1184,9 +1472,15 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>Optional compression algorithm used when generating keys.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>CompressionAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1244,9 +1538,14 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>Defines the file type stored within the PGP package.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>PGPFileType</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1256,9 +1555,30 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>Optional hash algorithm used when generating keys.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>HashAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1292,9 +1612,9 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>PGP signature type used when creating the key.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1383,9 +1703,33 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>Public key algorithm used for key creation.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>PublicKeyAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1419,9 +1763,25 @@ Get-PGPInspect -String $Signature</dev:code>
         <maml:description>
           <maml:para>Symmetric key algorithm used for encryption.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>SymmetricKeyAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -1530,9 +1890,15 @@ without encryption. Add -Detached to create a separate detached signature.</maml
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1566,9 +1932,14 @@ without encryption. Add -Detached to create a separate detached signature.</maml
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1578,9 +1949,30 @@ without encryption. Add -Detached to create a separate detached signature.</maml
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1638,9 +2030,9 @@ without encryption. Add -Detached to create a separate detached signature.</maml
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1650,9 +2042,33 @@ without encryption. Add -Detached to create a separate detached signature.</maml
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1687,9 +2103,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1738,9 +2170,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1762,9 +2200,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1786,9 +2229,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1846,9 +2310,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1858,9 +2322,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1895,9 +2383,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1946,9 +2450,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1970,9 +2480,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -1982,9 +2497,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2030,9 +2566,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2042,9 +2578,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2091,9 +2651,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2142,9 +2718,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2178,9 +2760,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2202,9 +2789,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2262,9 +2870,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2274,9 +2882,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2325,9 +2957,25 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2376,9 +3024,15 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2424,9 +3078,14 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2436,9 +3095,30 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2496,9 +3176,9 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2508,9 +3188,33 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2559,9 +3263,25 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2610,9 +3330,15 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2646,9 +3372,14 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2658,9 +3389,30 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2706,9 +3458,9 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2718,9 +3470,33 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2781,9 +3557,25 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2844,9 +3636,15 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2856,9 +3654,14 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2880,9 +3683,30 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2940,9 +3764,9 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2952,9 +3776,33 @@ Sign* parameter sets.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -2989,9 +3837,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3040,9 +3904,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3052,9 +3922,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3076,9 +3951,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3136,9 +4032,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3148,9 +4044,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3160,9 +4080,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3235,9 +4171,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3259,9 +4201,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3271,9 +4218,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3331,9 +4299,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3343,9 +4311,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3380,9 +4372,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3431,9 +4439,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3455,9 +4469,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3467,9 +4486,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3527,9 +4567,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3539,9 +4579,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3551,9 +4615,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3626,9 +4706,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3638,9 +4724,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3650,9 +4741,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3698,9 +4810,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3710,9 +4822,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3759,9 +4895,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3810,9 +4962,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional compression algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>CompressionAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3822,9 +4980,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Type of data being encrypted.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PGPFileType</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3834,9 +4997,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Optional hash algorithm for encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>HashAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3882,9 +5066,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>PGP signature type when signing data.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>Int32</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3894,9 +5078,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Public key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>PublicKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3918,9 +5126,25 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
           <maml:description>
             <maml:para>Symmetric key algorithm used during encryption.</maml:para>
           </maml:description>
-          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
           <dev:type>
-            <maml:name>Nullable`1</maml:name>
+            <maml:name>SymmetricKeyAlgorithmTag</maml:name>
             <maml:uri />
           </dev:type>
           <dev:defaultValue>None</dev:defaultValue>
@@ -3993,9 +5217,15 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
         <maml:description>
           <maml:para>Optional compression algorithm for encryption.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>CompressionAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4041,9 +5271,14 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
         <maml:description>
           <maml:para>Type of data being encrypted.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">PGPFileType</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Binary</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Text</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">UTF8</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>PGPFileType</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4065,9 +5300,30 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
         <maml:description>
           <maml:para>Optional hash algorithm for encryption.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">HashAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>HashAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4137,9 +5393,9 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
         <maml:description>
           <maml:para>PGP signature type when signing data.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">Int32</command:parameterValue>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>Int32</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4149,9 +5405,33 @@ Sign* parameter sets or the -SignOnly switch.</maml:para>
         <maml:description>
           <maml:para>Public key algorithm used during encryption.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">PublicKeyAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">RsaGeneral</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RsaEncrypt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RsaSign</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ElGamalEncrypt</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Dsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ECDH</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ECDsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ElGamalGeneral</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DiffieHellman</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EdDsa</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">EdDsa_Legacy</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_3</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_6</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_7</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_8</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_9</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_10</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Experimental_11</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>PublicKeyAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>
@@ -4212,9 +5492,25 @@ Sign* parameter sets.</maml:para>
         <maml:description>
           <maml:para>Symmetric key algorithm used during encryption.</maml:para>
         </maml:description>
-        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+        </command:parameterValueGroup>
         <dev:type>
-          <maml:name>Nullable`1</maml:name>
+          <maml:name>SymmetricKeyAlgorithmTag</maml:name>
           <maml:uri />
         </dev:type>
         <dev:defaultValue>None</dev:defaultValue>

--- a/en-US/PSPGP-help.xml
+++ b/en-US/PSPGP-help.xml
@@ -1,0 +1,5895 @@
+<?xml version="1.0" encoding="utf-8"?>
+<helpItems schema="maml" xmlns="http://msh">
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-PGPInspect</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PGPInspect</command:noun>
+      <maml:description>
+        <maml:para>Inspects PGP content and returns message metadata.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Inspects PGP content and returns message metadata.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="File">
+        <maml:name>Get-PGPInspect</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File to inspect.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Folder">
+        <maml:name>Get-PGPInspect</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing PGP files to inspect.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="String">
+        <maml:name>Get-PGPInspect</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Armored message content to inspect.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>File to inspect.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FolderPath</maml:name>
+        <maml:description>
+          <maml:para>Folder containing PGP files to inspect.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>String</maml:name>
+        <maml:description>
+          <maml:para>Armored message content to inspect.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PSPGP.PGPInspectInfo</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Represents the metadata extracted from a PGP message.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>$Signature = Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String 'Signed text'&#xD;
+Get-PGPInspect -String $Signature</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-PGPKey</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PGPKey</command:noun>
+      <maml:description>
+        <maml:para>Downloads a public key from a key server.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Downloads a public key from a key server.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-PGPKey</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeyServer</maml:name>
+          <maml:description>
+            <maml:para>URL of the key server.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>File path where the downloaded key is stored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Search</maml:name>
+          <maml:description>
+            <maml:para>Search string identifying the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeyServer</maml:name>
+        <maml:description>
+          <maml:para>URL of the key server.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutFilePath</maml:name>
+        <maml:description>
+          <maml:para>File path where the downloaded key is stored.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Search</maml:name>
+        <maml:description>
+          <maml:para>Search string identifying the key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-PGPKey -KeyServer "https://keys.example.com" -Search "user@example.com" -OutFilePath "key.asc"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Get-PGPKeyInfo</command:name>
+      <command:verb>Get</command:verb>
+      <command:noun>PGPKeyInfo</command:noun>
+      <maml:description>
+        <maml:para>Returns information about a PGP key such as algorithm, expiration and user IDs.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Returns information about a PGP key such as algorithm, expiration and user IDs.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="__AllParameterSets">
+        <maml:name>Get-PGPKeyInfo</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Paths to key files to inspect.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="True (ByValue, ByPropertyName)" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>Paths to key files to inspect.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>System.String[]</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PSPGP.PGPKeyInfo</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Information about a PGP key file.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Get-PGPKeyInfo -FilePath $PSScriptRoot\Keys\PublicPGP1.asc</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>New-PGPKey</command:name>
+      <command:verb>New</command:verb>
+      <command:noun>PGPKey</command:noun>
+      <maml:description>
+        <maml:para>Generates a new PGP key pair.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Generates a new PGP key pair.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="ClearText">
+        <maml:name>New-PGPKey</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Path to the private key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Path to the public key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Defines the file type stored within the PGP package.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password used to protect the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type used when creating the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used for key creation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UploadKeyServer</maml:name>
+          <maml:description>
+            <maml:para>Key server URL to upload the generated public key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>User name associated with the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Strength">
+        <maml:name>New-PGPKey</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether generated key files are ASCII armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Certainty</maml:name>
+          <maml:description>
+            <maml:para>Certainty value used when generating a key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EmitVersion</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version notation to the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Path to the private key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Path to the public key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Defines the file type stored within the PGP package.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeyExpirationInSeconds</maml:name>
+          <maml:description>
+            <maml:para>Key expiration in seconds. Use zero for no expiration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+          <dev:type>
+            <maml:name>Int64</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password used to protect the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type used when creating the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredCompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred compression algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>CompressionAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredHashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred hash algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>HashAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredSymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred symmetric algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>SymmetricKeyAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used for key creation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignatureExpirationInSeconds</maml:name>
+          <maml:description>
+            <maml:para>Signature expiration in seconds. Use zero for no expiration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+          <dev:type>
+            <maml:name>Int64</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Strength</maml:name>
+          <maml:description>
+            <maml:para>Key strength in bits.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UploadKeyServer</maml:name>
+          <maml:description>
+            <maml:para>Key server URL to upload the generated public key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UserName</maml:name>
+          <maml:description>
+            <maml:para>User name associated with the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StrengthCredential">
+        <maml:name>New-PGPKey</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether generated key files are ASCII armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Certainty</maml:name>
+          <maml:description>
+            <maml:para>Certainty value used when generating a key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object providing user name and password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>EmitVersion</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version notation to the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Path to the private key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Path to the public key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Defines the file type stored within the PGP package.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>KeyExpirationInSeconds</maml:name>
+          <maml:description>
+            <maml:para>Key expiration in seconds. Use zero for no expiration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+          <dev:type>
+            <maml:name>Int64</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type used when creating the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredCompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred compression algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>CompressionAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredHashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred hash algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">HashAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>HashAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PreferredSymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Preferred symmetric algorithms advertised by the generated key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag[]</command:parameterValue>
+          <command:parameterValueGroup>
+            <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+            <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+          </command:parameterValueGroup>
+          <dev:type>
+            <maml:name>SymmetricKeyAlgorithmTag[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used for key creation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignatureExpirationInSeconds</maml:name>
+          <maml:description>
+            <maml:para>Signature expiration in seconds. Use zero for no expiration.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+          <dev:type>
+            <maml:name>Int64</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Strength</maml:name>
+          <maml:description>
+            <maml:para>Key strength in bits.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+          <dev:type>
+            <maml:name>Int32</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UploadKeyServer</maml:name>
+          <maml:description>
+            <maml:para>Key server URL to upload the generated public key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Credential">
+        <maml:name>New-PGPKey</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object providing user name and password.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Path to the private key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Path to the public key file to create.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Defines the file type stored within the PGP package.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm used when generating keys.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type used when creating the key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used for key creation.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>UploadKeyServer</maml:name>
+          <maml:description>
+            <maml:para>Key server URL to upload the generated public key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Armor</maml:name>
+        <maml:description>
+          <maml:para>Controls whether generated key files are ASCII armored.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Certainty</maml:name>
+        <maml:description>
+          <maml:para>Certainty value used when generating a key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CompressionAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Optional compression algorithm used when generating keys.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential object providing user name and password.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>EmitVersion</maml:name>
+        <maml:description>
+          <maml:para>Adds the PGP version notation to the key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPrivate</maml:name>
+        <maml:description>
+          <maml:para>Path to the private key file to create.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPublic</maml:name>
+        <maml:description>
+          <maml:para>Path to the public key file to create.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FileType</maml:name>
+        <maml:description>
+          <maml:para>Defines the file type stored within the PGP package.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+        <maml:name>HashAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Optional hash algorithm used when generating keys.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>KeyExpirationInSeconds</maml:name>
+        <maml:description>
+          <maml:para>Key expiration in seconds. Use zero for no expiration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+        <dev:type>
+          <maml:name>Int64</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password used to protect the private key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PgpSignatureType</maml:name>
+        <maml:description>
+          <maml:para>PGP signature type used when creating the key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreferredCompressionAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Preferred compression algorithms advertised by the generated key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">CompressionAlgorithmTag[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Uncompressed</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Zip</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">ZLib</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">BZip2</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>CompressionAlgorithmTag[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreferredHashAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Preferred hash algorithms advertised by the generated key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">HashAlgorithmTag[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">MD5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha1</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">RipeMD160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">DoubleSha</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD2</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Tiger192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Haval5pass160</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">MD4</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_224</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_256_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_384</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Sha3_512_Old</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">SM3</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>HashAlgorithmTag[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PreferredSymmetricKeyAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Preferred symmetric algorithms advertised by the generated key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SymmetricKeyAlgorithmTag[]</command:parameterValue>
+        <command:parameterValueGroup>
+          <command:parameterValue required="false" variableLength="false">Null</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Idea</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">TripleDes</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Cast5</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Blowfish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Safer</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Des</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Aes256</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Twofish</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia128</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia192</command:parameterValue>
+          <command:parameterValue required="false" variableLength="false">Camellia256</command:parameterValue>
+        </command:parameterValueGroup>
+        <dev:type>
+          <maml:name>SymmetricKeyAlgorithmTag[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PublicKeyAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Public key algorithm used for key creation.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SignatureExpirationInSeconds</maml:name>
+        <maml:description>
+          <maml:para>Signature expiration in seconds. Use zero for no expiration.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Int64</command:parameterValue>
+        <dev:type>
+          <maml:name>Int64</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Strength</maml:name>
+        <maml:description>
+          <maml:para>Key strength in bits.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">Int32</command:parameterValue>
+        <dev:type>
+          <maml:name>Int32</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SymmetricKeyAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Symmetric key algorithm used for encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UploadKeyServer</maml:name>
+        <maml:description>
+          <maml:para>Key server URL to upload the generated public key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>UserName</maml:name>
+        <maml:description>
+          <maml:para>User name associated with the generated key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -UserName 'user' -Password 'secret'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>New-PGPKey -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Strength 4096 -Certainty 24 -EmitVersion</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Protect-PGP</command:name>
+      <command:verb>Protect</command:verb>
+      <command:noun>PGP</command:noun>
+      <maml:description>
+        <maml:para>Encrypts or signs files, folders or strings using one or more public keys.&#xD;
+Use -SignOnly or the Sign* parameter sets to create signatures&#xD;
+without encryption. Add -Detached to create a separate detached signature.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Encrypts or signs files, folders or strings using one or more public keys.&#xD;
+Use -SignOnly or the Sign* parameter sets to create signatures&#xD;
+without encryption. Add -Detached to create a separate detached signature.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="File">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File to encrypt when using the File parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for the encrypted file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Folder">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder to encrypt when using the Folder parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="String">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>String content to encrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SignFolder">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Detached</maml:name>
+          <maml:description>
+            <maml:para>Creates a detached signature over the original input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder to encrypt when using the Folder parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignOnly</maml:name>
+          <maml:description>
+            <maml:para>When specified, only a signature is produced instead of encrypting&#xD;
+the input. This parameter is automatically implied when using the&#xD;
+Sign* parameter sets.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SignFile">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Detached</maml:name>
+          <maml:description>
+            <maml:para>Creates a detached signature over the original input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File to encrypt when using the File parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for the encrypted file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignOnly</maml:name>
+          <maml:description>
+            <maml:para>When specified, only a signature is produced instead of encrypting&#xD;
+the input. This parameter is automatically implied when using the&#xD;
+Sign* parameter sets.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SignString">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Detached</maml:name>
+          <maml:description>
+            <maml:para>Creates a detached signature over the original input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files used for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignOnly</maml:name>
+          <maml:description>
+            <maml:para>When specified, only a signature is produced instead of encrypting&#xD;
+the input. This parameter is automatically implied when using the&#xD;
+Sign* parameter sets.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>String content to encrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ClearSignFolder">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSign</maml:name>
+          <maml:description>
+            <maml:para>Creates a clear-signed message that remains human readable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder to encrypt when using the Folder parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SymmetricFolder">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder to encrypt when using the Folder parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ClearSignFile">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSign</maml:name>
+          <maml:description>
+            <maml:para>Creates a clear-signed message that remains human readable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File to encrypt when using the File parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for the encrypted file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SymmetricFile">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File to encrypt when using the File parameter set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for the encrypted file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="ClearSignString">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSign</maml:name>
+          <maml:description>
+            <maml:para>Creates a clear-signed message that remains human readable.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignKey</maml:name>
+          <maml:description>
+            <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+          <dev:type>
+            <maml:name>FileInfo</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignPassword</maml:name>
+          <maml:description>
+            <maml:para>Password for the signing private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>String content to encrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="SymmetricString">
+        <maml:name>Protect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>AddVersionHeader</maml:name>
+          <maml:description>
+            <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Armor</maml:name>
+          <maml:description>
+            <maml:para>Controls whether file output is armored.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>CompressionAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional compression algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FileType</maml:name>
+          <maml:description>
+            <maml:para>Type of data being encrypted.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+          <maml:name>HashAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Optional hash algorithm for encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Headers</maml:name>
+          <maml:description>
+            <maml:para>Optional armored headers added to generated content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+          <dev:type>
+            <maml:name>Hashtable</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+          <maml:name>LiteralFileName</maml:name>
+          <maml:description>
+            <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OldFormat</maml:name>
+          <maml:description>
+            <maml:para>Uses the legacy packet format when set.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PgpSignatureType</maml:name>
+          <maml:description>
+            <maml:para>PGP signature type when signing data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>PublicKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Public key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>String content to encrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricKeyAlgorithm</maml:name>
+          <maml:description>
+            <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+          <dev:type>
+            <maml:name>Nullable`1</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric encryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>WithIntegrityCheck</maml:name>
+          <maml:description>
+            <maml:para>Controls whether an integrity check packet is added.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+          <dev:type>
+            <maml:name>Boolean</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>AddVersionHeader</maml:name>
+        <maml:description>
+          <maml:para>Adds the PGP version header to generated armored content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Armor</maml:name>
+        <maml:description>
+          <maml:para>Controls whether file output is armored.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClearSign</maml:name>
+        <maml:description>
+          <maml:para>Creates a clear-signed message that remains human readable.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>CompressionAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Optional compression algorithm for encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Detached</maml:name>
+        <maml:description>
+          <maml:para>Creates a detached signature over the original input.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>File to encrypt when using the File parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPublic</maml:name>
+        <maml:description>
+          <maml:para>Public key files used for encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FileType</maml:name>
+        <maml:description>
+          <maml:para>Type of data being encrypted.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FolderPath</maml:name>
+        <maml:description>
+          <maml:para>Folder to encrypt when using the Folder parameter set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="HashAlgorithmTag">
+        <maml:name>HashAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Optional hash algorithm for encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Headers</maml:name>
+        <maml:description>
+          <maml:para>Optional armored headers added to generated content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Hashtable</command:parameterValue>
+        <dev:type>
+          <maml:name>Hashtable</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="Name">
+        <maml:name>LiteralFileName</maml:name>
+        <maml:description>
+          <maml:para>Optional literal file name embedded in the PGP payload.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OldFormat</maml:name>
+        <maml:description>
+          <maml:para>Uses the legacy packet format when set.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutFilePath</maml:name>
+        <maml:description>
+          <maml:para>Output file path for the encrypted file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFolderPath</maml:name>
+        <maml:description>
+          <maml:para>Destination folder for encrypted files.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PgpSignatureType</maml:name>
+        <maml:description>
+          <maml:para>PGP signature type when signing data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>PublicKeyAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Public key algorithm used during encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SignKey</maml:name>
+        <maml:description>
+          <maml:para>Private key used for signing data. Mandatory when using the&#xD;
+Sign* parameter sets or the -SignOnly switch.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">FileInfo</command:parameterValue>
+        <dev:type>
+          <maml:name>FileInfo</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SignOnly</maml:name>
+        <maml:description>
+          <maml:para>When specified, only a signature is produced instead of encrypting&#xD;
+the input. This parameter is automatically implied when using the&#xD;
+Sign* parameter sets.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SignPassword</maml:name>
+        <maml:description>
+          <maml:para>Password for the signing private key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>String</maml:name>
+        <maml:description>
+          <maml:para>String content to encrypt.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SymmetricKeyAlgorithm</maml:name>
+        <maml:description>
+          <maml:para>Symmetric key algorithm used during encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Nullable`1</command:parameterValue>
+        <dev:type>
+          <maml:name>Nullable`1</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SymmetricPassphrase</maml:name>
+        <maml:description>
+          <maml:para>Passphrase used for symmetric encryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>WithIntegrityCheck</maml:name>
+        <maml:description>
+          <maml:para>Controls whether an integrity check packet is added.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">Boolean</command:parameterValue>
+        <dev:type>
+          <maml:name>Boolean</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Test -OutputFolderPath $PSScriptRoot\Encoded</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -OutFilePath $PSScriptRoot\Encoded\Test1.txt.pgp</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 3</maml:title>
+        <dev:code>Protect-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String "Sensitive text"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 4</maml:title>
+        <dev:code>Protect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String 'Sensitive text'</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 5</maml:title>
+        <dev:code>Protect-PGP -SignOnly -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Signed content"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 6</maml:title>
+        <dev:code>Protect-PGP -ClearSign -SignKey $PSScriptRoot\Keys\PrivatePGP1.asc -SignPassword 'secret' -String "Human readable signed content"</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Test-PGP</command:name>
+      <command:verb>Test</command:verb>
+      <command:noun>PGP</command:noun>
+      <maml:description>
+        <maml:para>Verifies PGP signatures for files, folders or strings.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Verifies PGP signatures for files, folders or strings.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="File">
+        <maml:name>Test-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSigned</maml:name>
+          <maml:description>
+            <maml:para>Verifies clear-signed content instead of regular signed content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>File path to verify.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key file used to verify signatures.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output path for verified clear content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SignaturePath</maml:name>
+          <maml:description>
+            <maml:para>Detached signature file for the input file.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThrowIfEncrypted</maml:name>
+          <maml:description>
+            <maml:para>Throws when encrypted content is passed to verify methods.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="Folder">
+        <maml:name>Test-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSigned</maml:name>
+          <maml:description>
+            <maml:para>Verifies clear-signed content instead of regular signed content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key file used to verify signatures.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing files to verify.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for verified clear content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThrowIfEncrypted</maml:name>
+          <maml:description>
+            <maml:para>Throws when encrypted content is passed to verify methods.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="String">
+        <maml:name>Test-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ClearSigned</maml:name>
+          <maml:description>
+            <maml:para>Verifies clear-signed content instead of regular signed content.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key file used to verify signatures.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Signature</maml:name>
+          <maml:description>
+            <maml:para>Detached signature for the string input.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Signed text or original text when Signature is provided.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>ThrowIfEncrypted</maml:name>
+          <maml:description>
+            <maml:para>Throws when encrypted content is passed to verify methods.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ClearSigned</maml:name>
+        <maml:description>
+          <maml:para>Verifies clear-signed content instead of regular signed content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>File path to verify.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPublic</maml:name>
+        <maml:description>
+          <maml:para>Public key file used to verify signatures.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FolderPath</maml:name>
+        <maml:description>
+          <maml:para>Folder containing files to verify.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutFilePath</maml:name>
+        <maml:description>
+          <maml:para>Output path for verified clear content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFolderPath</maml:name>
+        <maml:description>
+          <maml:para>Destination folder for verified clear content.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Signature</maml:name>
+        <maml:description>
+          <maml:para>Detached signature for the string input.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SignaturePath</maml:name>
+        <maml:description>
+          <maml:para>Detached signature file for the input file.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>String</maml:name>
+        <maml:description>
+          <maml:para>Signed text or original text when Signature is provided.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>ThrowIfEncrypted</maml:name>
+        <maml:description>
+          <maml:para>Throws when encrypted content is passed to verify methods.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues>
+      <command:returnValue>
+        <dev:type>
+          <maml:name>PSPGP.VerificationResult</maml:name>
+        </dev:type>
+        <maml:description>
+          <maml:para>Represents the outcome of a signature verification operation.</maml:para>
+        </maml:description>
+      </command:returnValue>
+    </command:returnValues>
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FolderPath $PSScriptRoot\Encoded</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 3</maml:title>
+        <dev:code>Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -FilePath $PSScriptRoot\Test\Test1.txt -SignaturePath $PSScriptRoot\Test\Test1.txt.sig</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 4</maml:title>
+        <dev:code>Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ClearSigned -ClearSigned</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 5</maml:title>
+        <dev:code>Test-PGP -FilePathPublic $PSScriptRoot\Keys\PublicPGP1.asc -String $ProtectedString -ThrowIfEncrypted</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+  <command:command xmlns:maml="http://schemas.microsoft.com/maml/2004/10" xmlns:dev="http://schemas.microsoft.com/maml/dev/2004/10" xmlns:MSHelp="http://msdn.microsoft.com/mshelp" xmlns:command="http://schemas.microsoft.com/maml/dev/command/2004/10">
+    <command:details>
+      <command:name>Unprotect-PGP</command:name>
+      <command:verb>Unprotect</command:verb>
+      <command:noun>PGP</command:noun>
+      <maml:description>
+        <maml:para>Removes PGP encryption from files or strings using a private key or symmetric passphrase.</maml:para>
+      </maml:description>
+    </command:details>
+    <maml:description>
+      <maml:para>Removes PGP encryption from files or strings using a private key or symmetric passphrase.</maml:para>
+    </maml:description>
+    <command:syntax>
+      <command:syntaxItem parameterSetName="FolderClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for decrypted output.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FolderCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for decrypted output.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FileCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Encrypted file to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for decrypted data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FileClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Encrypted file to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for decrypted data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StringClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Encrypted text to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StringCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Encrypted text to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FolderVerifyCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for decrypted output.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FolderVerifyClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for decrypted output.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FileVerifyCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Encrypted file to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for decrypted data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FileVerifyClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Encrypted file to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for decrypted data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StringVerifyClearText">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Password</maml:name>
+          <maml:description>
+            <maml:para>Password protecting the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Encrypted text to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StringVerifyCredential">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Credential</maml:name>
+          <maml:description>
+            <maml:para>Credential object with password for the private key.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+          <dev:type>
+            <maml:name>PSCredential</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPrivate</maml:name>
+          <maml:description>
+            <maml:para>Private key file used to decrypt data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePathPublic</maml:name>
+          <maml:description>
+            <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+          <dev:type>
+            <maml:name>String[]</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Encrypted text to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>Verify</maml:name>
+          <maml:description>
+            <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FolderSymmetric">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FolderPath</maml:name>
+          <maml:description>
+            <maml:para>Folder containing encrypted files.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutputFolderPath</maml:name>
+          <maml:description>
+            <maml:para>Destination folder for decrypted output.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="FileSymmetric">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>FilePath</maml:name>
+          <maml:description>
+            <maml:para>Encrypted file to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>OutFilePath</maml:name>
+          <maml:description>
+            <maml:para>Output file path for decrypted data.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+      <command:syntaxItem parameterSetName="StringSymmetric">
+        <maml:name>Unprotect-PGP</maml:name>
+        <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+          <maml:description>
+            <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+          <dev:type>
+            <maml:name>SwitchParameter</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>String</maml:name>
+          <maml:description>
+            <maml:para>Encrypted text to decrypt.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+        <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+          <maml:name>SymmetricPassphrase</maml:name>
+          <maml:description>
+            <maml:para>Passphrase used for symmetric decryption.</maml:para>
+          </maml:description>
+          <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+          <dev:type>
+            <maml:name>String</maml:name>
+            <maml:uri />
+          </dev:type>
+          <dev:defaultValue>None</dev:defaultValue>
+        </command:parameter>
+      </command:syntaxItem>
+    </command:syntax>
+    <command:parameters>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Credential</maml:name>
+        <maml:description>
+          <maml:para>Credential object with password for the private key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">PSCredential</command:parameterValue>
+        <dev:type>
+          <maml:name>PSCredential</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePath</maml:name>
+        <maml:description>
+          <maml:para>Encrypted file to decrypt.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPrivate</maml:name>
+        <maml:description>
+          <maml:para>Private key file used to decrypt data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="true" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FilePathPublic</maml:name>
+        <maml:description>
+          <maml:para>Public key files reserved for signed-and-encrypted verification workflows.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String[]</command:parameterValue>
+        <dev:type>
+          <maml:name>String[]</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>FolderPath</maml:name>
+        <maml:description>
+          <maml:para>Folder containing encrypted files.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>IgnoreIntegrityCheckFailure</maml:name>
+        <maml:description>
+          <maml:para>Ignores modification-detection/integrity-check failures during decryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutFilePath</maml:name>
+        <maml:description>
+          <maml:para>Output file path for decrypted data.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>OutputFolderPath</maml:name>
+        <maml:description>
+          <maml:para>Destination folder for decrypted output.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="false" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Password</maml:name>
+        <maml:description>
+          <maml:para>Password protecting the private key.</maml:para>
+        </maml:description>
+        <command:parameterValue required="false" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>String</maml:name>
+        <maml:description>
+          <maml:para>Encrypted text to decrypt.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>SymmetricPassphrase</maml:name>
+        <maml:description>
+          <maml:para>Passphrase used for symmetric decryption.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">String</command:parameterValue>
+        <dev:type>
+          <maml:name>String</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+      <command:parameter required="true" variableLength="false" globbing="false" pipelineInput="False" position="named" aliases="None">
+        <maml:name>Verify</maml:name>
+        <maml:description>
+          <maml:para>Reserved for future signed-and-encrypted verification support.</maml:para>
+        </maml:description>
+        <command:parameterValue required="true" variableLength="false">SwitchParameter</command:parameterValue>
+        <dev:type>
+          <maml:name>SwitchParameter</maml:name>
+          <maml:uri />
+        </dev:type>
+        <dev:defaultValue>None</dev:defaultValue>
+      </command:parameter>
+    </command:parameters>
+    <command:inputTypes>
+      <command:inputType>
+        <dev:type>
+          <maml:name>None</maml:name>
+        </dev:type>
+      </command:inputType>
+    </command:inputTypes>
+    <command:returnValues />
+    <maml:alertSet>
+      <maml:alert>
+        <maml:para></maml:para>
+      </maml:alert>
+    </maml:alertSet>
+    <command:examples>
+      <command:example>
+        <maml:title>EXAMPLE 1</maml:title>
+        <dev:code>Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -FolderPath $PSScriptRoot\Encoded -OutputFolderPath $PSScriptRoot\Decoded</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 2</maml:title>
+        <dev:code>Unprotect-PGP -FilePathPrivate $PSScriptRoot\Keys\PrivatePGP1.asc -Password 'secret' -String $Encrypted</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+      <command:example>
+        <maml:title>EXAMPLE 3</maml:title>
+        <dev:code>Unprotect-PGP -SymmetricPassphrase 'SymmetricPass123!' -String $Encrypted</dev:code>
+        <dev:remarks>
+          <maml:para></maml:para>
+        </dev:remarks>
+      </command:example>
+    </command:examples>
+    <command:relatedLinks />
+  </command:command>
+</helpItems>


### PR DESCRIPTION
## Summary

- Removes the MatejKafka.XmlDoc2CmdletDoc dependency and its build targets.
- Uses the public PSPublishModule 3.0.88 / PowerForge documentation owner.
- Regenerates Markdown and MAML and keeps binary external help discoverable with the assembly-named alias.

## Validation

- Full public-package module build completed.
- Markdown and MAML command identities match; MAML parses as XML.
- Regeneration is idempotent.
- Generated help was exercised through PowerShell 7 and Windows PowerShell 5.1.
- Repository-native .NET builds pass for the supported target frameworks.

## Scope

This PR is intentionally limited to dependency removal and functional build/package/import/Get-Help preservation. Documentation-content debt such as prose, examples, defaults, output annotations, and display enrichment is recorded separately and is not hand-edited in generated artifacts here.